### PR TITLE
Change SearchForm text color in AppBar

### DIFF
--- a/frontend/src/layout/AppBar.js
+++ b/frontend/src/layout/AppBar.js
@@ -55,7 +55,7 @@ const useStyles = makeStyles(theme => ({
   },
   title: {
     display: 'block',
-    color: theme.palette.common.white,
+    color: theme.palette.primary.contrastText,
     [theme.breakpoints.up('sm')]: {
       display: 'none'
     },

--- a/frontend/src/layout/SearchForm.js
+++ b/frontend/src/layout/SearchForm.js
@@ -4,6 +4,13 @@ import { Grid, Select, MenuItem, TextField, Button } from '@material-ui/core';
 import { Form, Field } from 'react-final-form';
 import { useHistory, useLocation } from 'react-router-dom';
 import { shallowEqual, useSelector, useStore } from 'react-redux';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  searchFormElement: {
+    color: theme.palette.primary.contrastText
+  },
+}));
 
 const FilterText = ({ input, ...otherProps }) => <TextField {...input} {...otherProps} />;
 
@@ -23,6 +30,7 @@ const TypeSelect = ({ input, ...otherProps }) => {
 };
 
 const SearchForm = () => {
+  const classes = useStyles();
   const history = useHistory();
 
   const location = useLocation();
@@ -49,13 +57,27 @@ const SearchForm = () => {
         <form onSubmit={handleSubmit}>
           <Grid container spacing={2}>
             <Grid item xs={5}>
-              <Field name="filter" component={FilterText} placeholder="Rechercher..." fullWidth />
+              <Field 
+                name="filter" 
+                component={FilterText} 
+                placeholder="Rechercher..." 
+                fullWidth 
+                InputProps={{className: classes.searchFormElement }} />
             </Grid>
             <Grid item xs={5}>
-              <Field name="type" component={TypeSelect} fullWidth />
+              <Field 
+                name="type" 
+                component={TypeSelect} 
+                fullWidth 
+                className={classes.searchFormElement} />
             </Grid>
             <Grid item xs={2}>
-              <Button variant="outlined" type="submit" fullWidth>
+              <Button 
+                variant="outlined" 
+                type="submit" 
+                fullWidth 
+                className={classes.searchFormElement}
+              >
                 Hop
               </Button>
             </Grid>


### PR DESCRIPTION
Bonjour,

Je me permets d'ouvrir une PR ici pour corriger un souci de contraste de couleur pour les champs de recherche dans la barre de navigation en haut. Alors que le titre et le menu à droite sont bien dans la bonne couleur constratée par rapport à la primaryColor choisie, le texte du SearchForm s'affichait en noir.

Avant : 
<img width="1680" alt="Capture d’écran 2023-01-11 à 23 09 50" src="https://user-images.githubusercontent.com/9048062/211929140-a4414ca6-9c37-4afc-bb62-878aa2ee393a.png">

Après : 
<img width="1680" alt="Capture d’écran 2023-01-11 à 23 08 39" src="https://user-images.githubusercontent.com/9048062/211929159-a0860449-d780-45e5-bbfc-09c99a0d81f4.png">
