### PR TITLE
[Minor] Remove external data servers and rename local one

### DIFF
--- a/frontend/src/config/dataServers.js
+++ b/frontend/src/config/dataServers.js
@@ -1,28 +1,33 @@
 const dataServers = {
-  av: {
+  default: {
     baseUrl: process.env.REACT_APP_MIDDLEWARE_URL,
     authServer: true,
     default: true,
     uploadsContainer: '/files'
   },
-  cdlt: {
-    baseUrl: 'https://data.lescheminsdelatransition.org/',
-    externalLinks: true,
-  },
-  colibris: {
-    name: 'Colibris',
-    baseUrl: 'https://colibris.social/',
-    sparqlEndpoint: 'https://colibris.social/sparql',
-    containers: {
-      colibris: {
-        'pair:Project': ['/lafabrique/projects'],
-        'pair:Document': ['/lemag/articles'],
-        'pair:Organization': ['/presdecheznous/organizations'],
-        'pair:Theme': ['/themes']
-      }
-    },
-    externalLinks: false // Colibris doesn't have a public frontend
-  }
+
+  // You can add additionnal external servers in this file
+  // Here is two examples:
+  //
+  // cdlt: {
+  //   baseUrl: 'https://data.lescheminsdelatransition.org/',
+  //   externalLinks: true,
+  // },
+  //
+  // colibris: {
+  //   name: 'Colibris',
+  //   baseUrl: 'https://colibris.social/',
+  //   sparqlEndpoint: 'https://colibris.social/sparql',
+  //   containers: {
+  //     colibris: {
+  //       'pair:Project': ['/lafabrique/projects'],
+  //       'pair:Document': ['/lemag/articles'],
+  //       'pair:Organization': ['/presdecheznous/organizations'],
+  //       'pair:Theme': ['/themes']
+  //     }
+  //   },
+  //   externalLinks: false // Colibris doesn't have a public frontend
+  // }
 };
 
 export default dataServers;


### PR DESCRIPTION
Hello,

Je ne connais pas l'historique du repo, mais je m'interroge sur le fait d'avoir des serveurs externes en dur dans ce fichier dans la codebase. En l'occurrence, ces derniers jours, le serveur `https://colibris.social/` avait du mal à répondre (l'url https://colibris.social/.well-known/void renvoyait une erreur 500), ce qui bloquait le chargement d'Archipelago.

Est-ce qu'on ne devrait pas juste avoir le middleware local par défaut dans ce repo ? Et charge aux instances qui déploient leur Archipelago de rajouter ces serveurs externes à leur convenance ?

Par ailleurs, le middleware local est nommé "av" (pour Assemblée Virtuelle ?), je propose de le renommer en "local" pour ne pas coupler le code fonctionnel du site au nom de l'organisation.

Si cette modification ne correspond pas, j'ai également proposé une solution palliative sur Semapps : https://github.com/assemblee-virtuelle/semapps/pull/1112 pour gérer les erreurs 500.