### PR TITLE
Rename Search Button

### DIFF
--- a/frontend/src/layout/SearchForm.js
+++ b/frontend/src/layout/SearchForm.js
@@ -5,6 +5,7 @@ import { Form, Field } from 'react-final-form';
 import { useHistory, useLocation } from 'react-router-dom';
 import { shallowEqual, useSelector, useStore } from 'react-redux';
 import { makeStyles } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
 
 const useStyles = makeStyles(theme => ({
   searchFormElement: {
@@ -57,28 +58,28 @@ const SearchForm = () => {
         <form onSubmit={handleSubmit}>
           <Grid container spacing={2}>
             <Grid item xs={5}>
-              <Field 
-                name="filter" 
-                component={FilterText} 
-                placeholder="Rechercher..." 
-                fullWidth 
+              <Field
+                name="filter"
+                component={FilterText}
+                placeholder="Rechercher..."
+                fullWidth
                 InputProps={{className: classes.searchFormElement }} />
             </Grid>
             <Grid item xs={5}>
-              <Field 
-                name="type" 
-                component={TypeSelect} 
-                fullWidth 
+              <Field
+                name="type"
+                component={TypeSelect}
+                fullWidth
                 className={classes.searchFormElement} />
             </Grid>
             <Grid item xs={2}>
-              <Button 
-                variant="outlined" 
-                type="submit" 
-                fullWidth 
+              <Button
+                variant="outlined"
+                type="submit"
                 className={classes.searchFormElement}
+                startIcon={<SearchIcon />}
               >
-                Hop
+                Rechercher
               </Button>
             </Grid>
           </Grid>


### PR DESCRIPTION
Hello,

Suite à des retours utilisateurs, le "Hop" de la barre d'application en haut semble mal compris (et non associé à la recherche). Je propose de modifier son libellé pour mettre "Rechercher" à la place : 

Avant : 
<img width="912" alt="Capture d’écran 2023-03-13 à 22 12 52" src="https://user-images.githubusercontent.com/9048062/224833571-f1248683-146b-42d8-a0a0-37cf2a5e6923.png">

Après : 
<img width="944" alt="Capture d’écran 2023-03-13 à 22 12 10" src="https://user-images.githubusercontent.com/9048062/224833448-50a7bd0f-f423-4c0b-b4ef-a933a9d2a019.png">
