### PR TITLE
Allowing to pick a pre-existing instance of `pair:ProjectType` when editing an instance of `pair:Project`

### DIFF
--- a/frontend/src/resources/Agent/Activity/Project/ProjectEdit.js
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectEdit.js
@@ -17,6 +17,9 @@ const ProjectEdit = props => (
         <ReferenceInput reference="Status" source="pair:hasStatus" filter={{ a: 'pair:ProjectStatus' }}>
           <SelectInput optionText="pair:label" />
         </ReferenceInput>
+        <ReferenceInput reference="Type" source="pair:hasType" filter={{ a: 'pair:ProjectType' }}>
+          <SelectInput optionText="pair:label" />
+        </ReferenceInput>
         <TextInput source="pair:homePage" fullWidth />
         <ImageInput source="image" accept="image/*">
           <ImageField source="src" />

--- a/frontend/src/resources/Agent/Activity/Project/ProjectFilterSidebar.js
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectFilterSidebar.js
@@ -37,6 +37,13 @@ const ProjectFilterSidebar = () => {
           limit={100}
           sort={{ field: 'pair:label', order: 'DESC' }}
         />
+        <ReferenceFilter
+            reference="Type"
+            source="pair:hasType"
+            limit={100}
+            filter={{ a: 'pair:ProjectType' }}
+            sort={{ field: 'pair:label', order: 'DESC' }}
+        />
       </CardContent>
     </Card>
   );

--- a/frontend/src/resources/Agent/Activity/Project/ProjectShow.js
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectShow.js
@@ -43,6 +43,9 @@ const ProjectShow = props => (
           <QuickAppendReferenceArrayField reference="Theme" source="pair:hasTopic">
             <ChipList primaryText="pair:label" linkType="show" externalLinks />
           </QuickAppendReferenceArrayField>
+          <QuickAppendReferenceArrayField reference="Type" source="pair:hasType">
+            <ChipList primaryText="pair:label" linkType="show" externalLinks />
+          </QuickAppendReferenceArrayField>
           <QuickAppendReferenceArrayField reference="Resource" source="pair:needs">
             <ChipList primaryText="pair:label" linkType="show" externalLinks />
           </QuickAppendReferenceArrayField>

--- a/frontend/src/resources/Agent/Activity/Project/index.js
+++ b/frontend/src/resources/Agent/Activity/Project/index.js
@@ -37,7 +37,8 @@ export default {
         'pair:involves': 'Implique',
         'pair:needs': 'Compétences requises',
         'pair:documentedBy': 'Documenté par',
-        'pair:hasTopic': 'A pour thème'
+        'pair:hasTopic': 'A pour thème',
+        'pair:hasType': 'Type',
       }
     }
   }


### PR DESCRIPTION
`Type` (`pair:ProjecType`) inputs have been added to
 - [x] Edit Project 
 - [x] Show Project

Do you see other places when `pair:ProjectType` should be referenced accordingly?

Fixes https://github.com/assemblee-virtuelle/archipelago/issues/119 maybe?

cc: @guillaumeAV @srosset81 @simonLouvet 

![edit_project](https://github.com/assemblee-virtuelle/archipelago/assets/133956097/fe6e6ab0-605b-4c5a-97b4-1bc817258ee4)
![show_project](https://github.com/assemblee-virtuelle/archipelago/assets/133956097/cc091374-c990-4059-82f2-8b45fbe2a38d)
