### PR TITLE
[Minor] Improve TreeMenu

### DIFF
--- a/frontend/src/config/theme.js
+++ b/frontend/src/config/theme.js
@@ -7,7 +7,10 @@ const theme = createTheme({
   palette: {
     primary: { main: '#28ccfb', contrastText: '#ffffff' },
     secondary: { main: '#bcef5b' },
-    grey: { main: '#e0e0e0' }
+    grey: { main: '#e0e0e0' },
+    background: {
+      default: '#efefef',
+    }
   },
   typography: {
     details: {
@@ -70,6 +73,15 @@ const theme = createTheme({
           }
         }
       }
+    },
+    RaMenuItemLink: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '&.RaMenuItemLink-active': {
+              borderLeft: `3px solid ${theme.palette.primary.main}`,
+          },
+        }),
+      },
     },
     MuiTab: {
       styleOverrides: {

--- a/frontend/src/layout/Layout.js
+++ b/frontend/src/layout/Layout.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Layout as RaLayout } from 'react-admin';
 import makeStyles from '@mui/styles/makeStyles';
 import AppBar from './AppBar';
@@ -7,7 +7,7 @@ import TreeMenu from './TreeMenu/TreeMenu';
 const useStyles = makeStyles(theme => ({
   layout: {
     '& .RaLayout-content': {
-      backgroundColor: '#efefef',
+      backgroundColor: theme.palette.background.default,
       paddingTop: theme.spacing(1),
       paddingRight: theme.spacing(2),
       paddingBottom: theme.spacing(2),
@@ -24,23 +24,18 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const Layout = ({ appBar, menu, userMenu, children, labelNbLines, ...otherProps }) => {
+const Layout = ({ appBar, menu, children, ...otherProps }) => {
   const classes = useStyles();
-  const LayoutTreeMenu = useMemo(() => props => <TreeMenu {...props} labelNbLines={labelNbLines} />, [labelNbLines]);
   return (
     <RaLayout
       {...otherProps}
       className={classes.layout}
-      appBar={appBar}
-      menu={menu ? menu : LayoutTreeMenu}
+      appBar={AppBar}
+      menu={TreeMenu}
     >
       {children}
     </RaLayout>
   );
-};
-
-Layout.defaultProps = {
-  appBar: AppBar
 };
 
 export default Layout;

--- a/frontend/src/layout/TreeMenu/ResourceMenuLink.js
+++ b/frontend/src/layout/TreeMenu/ResourceMenuLink.js
@@ -2,13 +2,11 @@ import React from 'react';
 import { MenuItemLink } from 'react-admin';
 import DefaultIcon from '@mui/icons-material/ViewList';
 
-const ResourceMenuLink = ({ resource, onClick, open }) => (
+const ResourceMenuLink = ({ resource }) => (
   <MenuItemLink
     to={`/${resource.name}`}
-    primaryText={(resource.options && resource.options.label) || resource.name}
+    primaryText={resource.options?.label || resource.name}
     leftIcon={resource.icon ? <resource.icon /> : <DefaultIcon />}
-    onClick={onClick}
-    sidebarIsOpen={open}
   />
 );
 

--- a/frontend/src/layout/TreeMenu/SubMenu.js
+++ b/frontend/src/layout/TreeMenu/SubMenu.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { List, MenuItem, ListItemIcon, Typography, Collapse, Tooltip } from '@mui/material';
+import { MenuItemLink, useSidebarState } from 'react-admin';
+import { MenuList, Collapse, Tooltip } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 
 const useStyles = makeStyles(theme => ({
-  icon: { minWidth: theme.spacing(5) },
   sidebarIsOpen: {
     '& a': {
       paddingLeft: theme.spacing(4),
@@ -19,16 +19,21 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const SubMenu = ({ handleToggle, sidebarIsOpen, isOpen, name, icon, children, dense }) => {
+const SubMenu = ({ handleToggle, isOpen, name, icon, children }) => {
   const classes = useStyles();
+  const [sidebarIsOpen, setSidebarIsOpen] = useSidebarState();
 
   const header = (
-    <MenuItem dense={dense} onClick={handleToggle}>
-      <ListItemIcon className={classes.icon}>{isOpen ? <ExpandMore /> : icon}</ListItemIcon>
-      <Typography variant="inherit" color="textSecondary">
-        {name}
-      </Typography>
-    </MenuItem>
+    <MenuItemLink
+      to={`/${name}`}
+      primaryText={name}
+      leftIcon={isOpen ? <ExpandMore /> : icon}
+      onClick={(e) => {
+        e.preventDefault();
+        setSidebarIsOpen(true);
+        handleToggle();
+      }}
+    />
   );
 
   return (
@@ -41,14 +46,13 @@ const SubMenu = ({ handleToggle, sidebarIsOpen, isOpen, name, icon, children, de
         </Tooltip>
       )}
       <Collapse in={isOpen} timeout="auto" unmountOnExit>
-        <List
-          dense={dense}
+        <MenuList
           component="div"
           disablePadding
           className={sidebarIsOpen ? classes.sidebarIsOpen : classes.sidebarIsClosed}
         >
           {children}
-        </List>
+        </MenuList>
       </Collapse>
     </>
   );

--- a/frontend/src/layout/TreeMenu/TreeMenu.js
+++ b/frontend/src/layout/TreeMenu/TreeMenu.js
@@ -1,115 +1,116 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { useResourceDefinitions, Logout } from 'react-admin';
-import { useLocation } from 'react-router';
-import { useMediaQuery, Box } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
-import DefaultIcon from '@mui/icons-material/ViewList';
-import SubMenu from './SubMenu';
-import ResourceMenuLink from './ResourceMenuLink';
+import React, { useState, useEffect, useMemo } from "react";
+import { useResourceDefinitions, Logout, Menu, useGetIdentity, MenuItemLink, useTranslate } from "react-admin";
+import { useLocation } from "react-router";
+import { useMediaQuery, Divider } from "@mui/material";
+import DefaultIcon from "@mui/icons-material/ViewList";
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import LoginIcon from '@mui/icons-material/Login';
+import SubMenu from "./SubMenu";
+import ResourceMenuLink from "./ResourceMenuLink";
 
-const useStyles = makeStyles(theme => ({
-  treeMenu: props => ({
-    '& .MuiMenuItem-root': {
-      whiteSpace: 'normal',
-      maxWidth: 240,
-      maxHeight: 10 + 24 * props.labelNbLines,
-      paddingLeft: 56,
-      textOverflow: 'ellipsis',
-      overflow: 'hidden',
-      display: '-webkit-box',
-      '-webkit-line-clamp': props.labelNbLines,
-      '-webkit-box-orient': 'vertical',
-      '& > .MuiListItemIcon-root': {
-        position: 'absolute',
-        left: 16
-      }
-    },
-    '& .MuiCollapse-root': {
-      '& .MuiMenuItem-root': {
-        paddingLeft: 72,
-        '& > .MuiListItemIcon-root': {
-          left: 32
-        }
-      }
-    }
-  })
-}));
+const TreeMenu = () => {
+  const isXSmall = useMediaQuery((theme) => theme.breakpoints.down("sm"));
 
-const TreeMenu = ({ onMenuClick, dense = false, openAll = false, labelNbLines = 1 }) => {
-  const isXSmall = useMediaQuery(theme => theme.breakpoints.down('sm'));
-  const isSmall = useMediaQuery(theme => theme.breakpoints.only('sm'));
-  labelNbLines = isSmall ? 1 : labelNbLines;
-  const classes = useStyles({ labelNbLines });
-  // const [open] = useSidebarState();
-    const resourceDefinitions = useResourceDefinitions();
-  const resources = useMemo(() => Object.values(resourceDefinitions), [resourceDefinitions]);
+  const resourceDefinitions = useResourceDefinitions();
+  const resources = useMemo(
+    () => Object.values(resourceDefinitions),
+    [resourceDefinitions]
+  );
 
-  // TODO create a specialized hook, as this is used several times in the layout (which cannot use useResourceDefinition)
   const location = useLocation();
   const matches = location.pathname.match(/^\/([^/]+)/);
   const currentResourceName = matches ? matches[1] : null;
 
+  const { identity } = useGetIdentity();
+  const isLogged = identity && identity.id !== '';
+
+  const translate = useTranslate();
+
   const [openSubMenus, setOpenSubMenus] = useState({});
-  const handleToggle = menu => {
-    setOpenSubMenus(state => ({ ...state, [menu]: !state[menu] }));
+  const handleToggle = (menu) => {
+    setOpenSubMenus((state) => ({ ...state, [menu]: !state[menu] }));
   };
 
   // Get menu root items
-  const menuRootItems = useMemo(() => resources.filter(r => r.options && !r.options.parent), [resources]);
+  const menuRootItems = useMemo(
+    () => resources.filter((r) => !r.options?.parent),
+    [resources]
+  );
 
   // Calculate available categories
   const categories = useMemo(() => {
     const names = resources.reduce((categories, resource) => {
-      if (resource.options && resource.options.parent) categories.push(resource.options.parent);
+      if (resource.options?.parent) {
+        categories.push(resource.options.parent);
+      }
       return categories;
     }, []);
-    return resources.filter(resource => names.includes(resource.name));
+    return resources.filter((resource) => names.includes(resource.name));
   }, [resources]);
 
-  // Open all submenus by default
+  // Open submenu of current page
   useEffect(() => {
-    const currentResource = resources.find(resource => resource.name === currentResourceName);
-    const currentCategory =
-      currentResource && categories.find(category => category.name === currentResource.options?.parent);
-    const defaultValues = categories.reduce((acc, category) => {
-      acc[category.name] = openAll || (currentCategory && category.name === currentCategory.name);
-      return acc;
-    }, {});
-    setOpenSubMenus(state => ({ ...defaultValues, ...state }));
-  }, [categories, resources, currentResourceName, openAll]);
+    const currentResource = resources.find(
+      (resource) => resource.name === currentResourceName
+    );
 
-  return (
-    <Box mt={2} className={classes.treeMenu}>
-      {menuRootItems.map(menuRootItem => (
-        <Box key={menuRootItem.name}>
-          {categories.includes(menuRootItem) ? (
-            <SubMenu
-              key={menuRootItem.name}
-              handleToggle={() => handleToggle(menuRootItem.name)}
-              isOpen={openSubMenus[menuRootItem.name]}
-              sidebarIsOpen
-              name={(menuRootItem.options && menuRootItem.options.label) || menuRootItem.name}
-              icon={menuRootItem.icon ? <menuRootItem.icon /> : <DefaultIcon />}
-              dense={dense}
-            >
-              {resources
-                .filter(resource => resource.hasList && resource.options.parent === menuRootItem.name)
-                .map(resource => (
-                  <ResourceMenuLink key={resource.name} resource={resource} onClick={onMenuClick} open={true} />
-                ))}
-            </SubMenu>
-          ) : (
-            <>
-              {menuRootItem.hasList && (
-                <ResourceMenuLink key={menuRootItem.name} resource={menuRootItem} onClick={onMenuClick} open={true} />
-              )}
-            </>
-          )}
-        </Box>
-      ))}
-      {isXSmall && <Logout />}
-    </Box>
-  );
+    const currentCategory =
+      currentResource &&
+      categories.find(
+        (category) => category.name === currentResource.options?.parent
+      );
+
+    if (currentCategory) {
+      setOpenSubMenus((state) => ({ ...state, [currentCategory.name]: true }));
+    }
+  }, [categories, resources, currentResourceName]);
+
+  const menuItems = menuRootItems.map((menuRootItem) => {
+    return categories.includes(menuRootItem) ? (
+      <SubMenu
+        key={menuRootItem.name}
+        handleToggle={() => handleToggle(menuRootItem.name)}
+        isOpen={openSubMenus[menuRootItem.name]}
+        name={(menuRootItem.options && menuRootItem.options.label) || menuRootItem.name}
+        icon={menuRootItem.icon ? <menuRootItem.icon /> : <DefaultIcon />}
+      >
+        {resources
+          .filter(resource => resource.hasList && resource.options.parent === menuRootItem.name)
+          .map(resource => (
+            <ResourceMenuLink key={resource.name} resource={resource} />
+          ))}
+      </SubMenu>
+    ) : (
+      menuRootItem.hasList && (
+        <ResourceMenuLink key={menuRootItem.name} resource={menuRootItem} />
+      )
+    );
+  });
+
+  if (isXSmall) {
+    menuItems.push(<Divider key="divider" />);
+
+    if (isLogged) {
+      menuItems.push(<Logout key="logout" />)
+    } else {
+      menuItems.push(
+        <MenuItemLink
+          key="signup"
+          to={'/login?signup=true'}
+          primaryText={translate('auth.action.signup')}
+          leftIcon={<LockOpenIcon />}
+        />,
+        <MenuItemLink
+          key="login"
+          to={'/login'}
+          primaryText={translate('auth.action.login')}
+          leftIcon={<LoginIcon />}
+        />,
+      );
+    }
+  }
+
+  return <Menu children={menuItems} />;
 };
 
 export default TreeMenu;


### PR DESCRIPTION
Hello, 

Voici quelques améliorations concernant le menu latéral : 

1/ Meilleure utilisation des éléments de React-admin pour prendre en compte toute la largeur de l'espace menu pour les items. J'ai aussi supprimé les props qui ne sont plus implémentés dans le code de react-admin, et nettoyé les styles custom rajoutés devenus inutiles.

Avant : 
<img width="273" alt="Capture d’écran 2023-07-27 à 23 28 04" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/a1f4debb-0eff-42a5-bf3f-aa18dc6fc684">

Après : 
<img width="262" alt="Capture d’écran 2023-07-27 à 23 28 16" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/f43e99f0-502d-4517-bf28-15e78bc80377">

2/ Meilleure intégration des submenus quand le menu est replié, comme recommandé dans les exemples de React-admin.

Avant : 
<img width="86" alt="Capture d’écran 2023-07-27 à 23 28 32" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/0dd1c998-50ce-411b-abb0-e78c6b9c8521">

Après : 
<img width="84" alt="Capture d’écran 2023-07-27 à 23 28 47" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/87ff2fc5-8557-4597-9cdf-d38b4c156f3a">

3/ Correction de la position des tooltips

Avant : 
<img width="241" alt="Capture d’écran 2023-07-27 à 23 29 41" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/76e52563-6967-453f-9314-2eeb679d53b4">

Après : 
<img width="123" alt="Capture d’écran 2023-07-27 à 23 29 56" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/da9374d0-fb76-4d4b-8530-700908051437">

4/ Ajout d'un indicatif de sélection de l'item actif (trait de 3px de la couleur primaire du thème)

<img width="262" alt="Capture d’écran 2023-07-27 à 23 28 16" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/096bcdae-fa3d-4f78-9b8e-16ad17bf9893">

5/ Depuis le passage à la v1.0.0, un bouton "Déconnexion" a été rajouté dans le menu, dans la version mobile seulement, mais celui-ci apparaissait tout le temps, même si on n'était pas connecté. J'ai modifié pour ajouter les boutons d'inscription et de login à la place dans ce cas. Vu que les boutons d'inscription/login/logout sont toujours disponible dans l'appBar en haut à droite dans la version mobile, il est aussi possible de ne pas rajouter ces boutons dans le menu...

Avant : 
<img width="428" alt="Capture d’écran 2023-07-27 à 23 30 34" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/8e330462-94e4-4e59-b6d0-9dc0f218ebce">

Après : 
<img width="447" alt="Capture d’écran 2023-07-27 à 23 43 48" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/ace77e57-b3e3-41fa-9729-202811286d46">

<img width="432" alt="Capture d’écran 2023-07-27 à 23 44 34" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/efd594ed-38d1-4783-a78d-081f9a1aba3b">
