### PR TITLE
Feat: Add a dbMigration service

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,41 @@ Additionally, frontend packages need to be rebuilt on every changes, or they wil
 
 Thanks to git hooks, the frontend packages will also be published to Yalc whenever git branches are changed.
 
+## Run database migrations
+
+You can use `dbMigrate` script to create database migrations and/or runs them.
+Migrations files are created by default in `middleware/migrations` folder.
+
+```bash
+cd middleware
+yarn run dbMigrate
+
+# To create a new migration file
+yarn run dbMigrate create --name archipelago-changeResourceAttribute
+
+# To list all migrations
+yarn run dbMigrate status
+
+# To apply next not applied migration
+yarn run dbMigration up
+
+# To apply a given migration
+yarn run dbMigration up --name archipelago-changeResourceAttribute
+
+# To apply all not applied migrations
+yarn run dbMigration up --latest
+
+# To rollback previous applied migration
+yarn run dbMigration down
+
+# To rollback a migration
+yarn run dbMigration down --name archipelago-changeResourceAttribute
+
+# To rollback all applied migrations
+yarn run dbMigration down --earliest
+```
+
+You can also call dbMigration actions from REPL middleware with `call dbMigration.status` for example.
 
 ## Deploying to production
 

--- a/middleware/dbMigrate.js
+++ b/middleware/dbMigrate.js
@@ -1,0 +1,77 @@
+const { Command } = require('commander');
+const { ServiceBroker } = require('moleculer');
+const { CoreService } = require('@semapps/core');
+const CONFIG = require('./config/config');
+const dbMigrationsService = require('./services/dbMigrations.service');
+
+const broker = new ServiceBroker({
+  logLevel: "warn",
+});
+
+// Minimal core services to run triplestore queries
+broker.createService({
+  name: 'core',
+  mixins: [CoreService],
+  settings: {
+    activitypub: false,
+    api: {
+      port: CONFIG.PORT + 1,
+    },
+    jsonld: {},
+    ldp: false,
+    signature: false,
+    sparqlEndpoint: false,
+    void: false,
+    webacl: false,
+    webfinger: false,
+
+    baseUrl: CONFIG.HOME_URL,
+    triplestore: {
+      url: CONFIG.SPARQL_ENDPOINT,
+      user: CONFIG.JENA_USER,
+      password: CONFIG.JENA_PASSWORD,
+      mainDataset: CONFIG.MAIN_DATASET,
+    },
+  }});
+
+broker.createService(dbMigrationsService);
+
+const executeAction = async (action, options) => {
+  await broker.start();
+  await broker.call(`dbMigrations.${action}`, options);
+  await broker.stop();
+}
+
+const program = new Command();
+program
+  .name('dbMigrate')
+  .description('CLI to run Triplestore migrations');
+
+program.command('create')
+  .description('Creates a new migration file')
+  .option('--name <string>', 'Migration name')
+  .action(async (options) => await executeAction('create', options));
+
+program.command('status')
+  .description('Lists all migrations and their status and applied date if any')
+  .action(async (options) => await executeAction('status', options));
+
+program.command('up')
+  .description('Applies given migrations')
+  .option('--name <string>', 'Migration name')
+  .option('--latest', 'Runs all not applied migrations')
+  .action(async (options) => await executeAction('up', options));
+
+program.command('down')
+  .description('Rollbacks given migrations')
+  .option('--name <string>', 'Migration name')
+  .option('--earliest', 'Rollbacks all applied migrations')
+  .option('--force', 'Deletes also unknown migrations in database')
+  .action(async (options) => await executeAction('down', options));
+
+program.command('clear')
+  .description('Clears all migration data in database')
+  .option('--yes', 'Effectively executes the command')
+  .action(async (options) => await executeAction('clear', options));
+
+program.parse();

--- a/middleware/migrations/1698701152748_archipelago-updateFilesType.js
+++ b/middleware/migrations/1698701152748_archipelago-updateFilesType.js
@@ -1,0 +1,25 @@
+module.exports = {
+  // Since middleware-0.6.0-alpha-1, type attribute for file resource
+  // has changed from <semapps:File> to <http://semapps.org/ns/core#File>
+
+  up: async ({ update }) => {
+    await update({
+      query: `
+        DELETE { ?s ?p <semapps:File> . }
+        INSERT { ?s ?p <http://semapps.org/ns/core#File> . }
+        WHERE { ?s ?p <semapps:File> . }
+      `,
+      webId: 'system'
+    });
+  },
+  down: async ({ update }) => {
+    await update({
+      query: `
+        DELETE { ?s ?p <http://semapps.org/ns/core#File> . }
+        INSERT { ?s ?p <semapps:File> . }
+        WHERE { ?s ?p <http://semapps.org/ns/core#File> . }
+      `,
+      webId: 'system'
+    });
+  },
+};

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -8,23 +8,25 @@
   "scripts": {
     "dev": "moleculer-runner --repl --hot services",
     "start": "moleculer-runner services",
+    "dbMigrate": "node ./dbMigrate",
     "link-semapps-packages": "yarn link @semapps/activitypub @semapps/auth @semapps/backup @semapps/core @semapps/importer @semapps/inference @semapps/jsonld @semapps/ldp @semapps/middlewares @semapps/mime-types @semapps/pod @semapps/signature @semapps/sparql-endpoint @semapps/triplestore @semapps/void @semapps/webacl @semapps/webfinger @semapps/webhooks @semapps/webid",
     "unlink-semapps-packages": "yarn unlink @semapps/activitypub @semapps/auth @semapps/backup @semapps/core @semapps/importer @semapps/inference @semapps/jsonld @semapps/ldp @semapps/middlewares @semapps/mime-types @semapps/pod @semapps/signature @semapps/sparql-endpoint @semapps/triplestore @semapps/void @semapps/webacl @semapps/webfinger @semapps/webhooks @semapps/webid"
   },
   "dependencies": {
+    "@rdfjs/data-model": "^1.3.4",
     "@semapps/auth": "0.6.0-alpha.1",
     "@semapps/backup": "0.6.0-alpha.1",
     "@semapps/core": "0.6.0-alpha.1",
     "@semapps/inference": "0.6.0-alpha.1",
     "@semapps/webid": "0.6.0-alpha.1",
+    "commander": "^11.1.0",
     "dotenv-flow": "^3.2.0",
+    "fix-esm": "^1.0.1",
     "ioredis": "^4.17.3",
+    "ldp-navigator": "^1.2.20",
     "moleculer": "^0.14.18",
     "moleculer-repl": "^0.6.3",
     "moleculer-web": "^0.10.0-beta1",
-    "url-join": "^4.0.1",
-    "@rdfjs/data-model": "^1.3.4",
-    "fix-esm": "^1.0.1",
-    "ldp-navigator": "^1.2.20"
+    "url-join": "^4.0.1"
   }
 }

--- a/middleware/services/dbMigrations.service.js
+++ b/middleware/services/dbMigrations.service.js
@@ -1,0 +1,430 @@
+const fs = require("fs");
+const path = require("path");
+const CONFIG = require("../config/config");
+
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const GRAY = '\x1b[90m';
+const DEFAULT = '\x1b[0m';
+
+const MIGRATION_FILE_TEMPLATE = `module.exports = {
+  up: async ({ query, insert, update }) => {
+    /*
+     * You can use 'query', 'insert' and 'update' actions from triplestore service
+     * Documentation for these methods can be found here: https://semapps.org/docs/middleware/triplestore
+     * Example:
+     *
+     * const queryResult = await query({
+     *   query: \`
+     *     SELECT ?s ?p ?o
+     *     WHERE {
+     *       ?subject ?predicate ?object
+     *     }
+     *   \`,
+     * });
+     */
+
+  },
+  down: async ({ query, insert, update }) => {
+    /*
+     * This function must undo what is done in the above "up" function.
+     * If things are not undoable, it must ensure that the database will be in a coherent working state
+     */
+
+  },
+};
+`;
+
+module.exports = {
+  name: "dbMigrations",
+  settings: {
+    migrationsFolder: path.join(__dirname, "../migrations"),
+    graphName: 'http://semapps.org/migrations',
+    baseUrl: CONFIG.HOME_URL,
+  },
+
+  methods: {
+    logInfo(text) {
+      console.log(`${GRAY}${text}${DEFAULT}`);
+    },
+
+    logSuccess(text) {
+      console.log(`${GREEN}${text}${DEFAULT}`);
+    },
+
+    logWarn(text) {
+      console.log(`${YELLOW}${text}${DEFAULT}`);
+    },
+
+    logError(text) {
+      console.log(`${RED}${text}${DEFAULT}`);
+    },
+
+    /**
+     * Lists files and in-database migrations found and merges them
+     * @returns {{ name: string, appliedDate: string, onlyDb: boolean }[]}
+     */
+    async listMigrations() {
+      const migrations = fs
+        .readdirSync(this.settings.migrationsFolder)
+        .filter((file) => /\d+_.*\.js/.test(file))
+        .map((file) => ({
+          name: file.substring(0, file.lastIndexOf(".")), // Strip extension
+          appliedDate: null,
+          onlyDb: false,
+        }));
+
+      const databaseMigrations = await this.broker.call("triplestore.query", {
+        query: `
+          SELECT ?name ?appliedDate
+          WHERE {
+            GRAPH <${this.settings.graphName}> {
+              ?name <http://purl.org/dc/terms/created> ?appliedDate
+            }
+          }
+        `,
+      });
+
+      const resourceUri = new URL("migrations/", this.settings.baseUrl).href;
+
+      databaseMigrations.forEach((migration) => {
+        const name = migration.name.value.substring(resourceUri.length);
+        const index = migrations.findIndex(
+          (localMigration) => localMigration.name === name
+        );
+
+        if (index > -1) {
+          migrations[index].appliedDate = migration.appliedDate.value;
+        } else {
+          migrations.push({
+            name,
+            appliedDate: migration.appliedDate.value,
+            onlyDb: true,
+          });
+        }
+      });
+
+      migrations.sort((a, b) => (a.name < b.name ? -1 : 1));
+      return migrations;
+    },
+
+    /**
+     * Applies a selected migration and saves it in db
+     * @param {{ name: string, appliedDate: string, onlyDb: boolean }} currentMigration
+     * @returns {boolean} True if successful, false otherwise
+     */
+    async internalUp(currentMigration) {
+      try {
+        this.logInfo(`Applying migration "${currentMigration.name}"...`);
+
+        const migrationFile = require(path.join(
+          this.settings.migrationsFolder,
+          `${currentMigration.name}.js`
+        ));
+        await migrationFile.up({
+          query: (opts) => this.broker.call('triplestore.query', opts),
+          insert: (opts) => this.broker.call('triplestore.insert', opts),
+          update: (opts) => this.broker.call('triplestore.update', opts),
+        });
+
+        const resourceUri = new URL(
+          `migrations/${currentMigration.name}`,
+          this.settings.baseUrl
+        ).href;
+        await this.broker.call("triplestore.insert", {
+          graphName: this.settings.graphName,
+          resource: `<${resourceUri}> <http://purl.org/dc/terms/created> "${new Date().toISOString()}"`,
+        });
+
+        this.logSuccess(
+          `Migration "${currentMigration.name}" is successfully applied.`
+        );
+        return true;
+      } catch (e) {
+        this.logError(e.message);
+        this.logError(
+          `An error occurred during migration "${currentMigration.name}". Migration is not applied.`
+        );
+        return false;
+      }
+    },
+
+    /**
+     * Rollbacks a selected migration and deletes it from db
+     * @param {{ name: string, appliedDate: string, onlyDb: boolean }} currentMigration
+     * @param {boolean} force
+     * @returns {boolean} True if successful, false otherwise
+     */
+    async internalDown(currentMigration, force) {
+      try {
+        this.logInfo(`Rollbacking migration "${currentMigration.name}"...${DEFAULT}`);
+
+        if (currentMigration.onlyDb && !force) {
+          throw new Error(
+            `Migration "${currentMigration.name}" was only found in database, and unknown locally. You can use "--force" parameter to delete it`
+          );
+        }
+
+        if (!currentMigration.onlyDb) {
+          const migrationFile = require(path.join(
+            this.settings.migrationsFolder,
+            `${currentMigration.name}.js`
+          ));
+          await migrationFile.down({
+            query: (opts) => this.broker.call('triplestore.query', opts),
+            insert: (opts) => this.broker.call('triplestore.insert', opts),
+            update: (opts) => this.broker.call('triplestore.update', opts),
+          });
+        }
+
+        const resourceUri = new URL(
+          `migrations/${currentMigration.name}`,
+          this.settings.baseUrl
+        ).href;
+        await this.broker.call("triplestore.update", {
+          query: `
+            WITH <${this.settings.graphName}>
+            DELETE { <${resourceUri}> ?p ?o }
+            WHERE { <${resourceUri}> ?p ?o }
+          `,
+        });
+
+        if (currentMigration.onlyDb) {
+          this.logWarn(
+            `Migration "${currentMigration.name}" is successfully deleted in database. No rollback done`
+          );
+        } else {
+          this.logSuccess(
+            `Migration "${currentMigration.name}" is successfully rollbacked.`
+          );
+        }
+        return true;
+      } catch (e) {
+        this.logError(e.message);
+        this.logError(
+          `An error occurred when rollbacking migration "${currentMigration.name}". Migration is not rollbacked.`
+        );
+        return false;
+      }
+    },
+  },
+
+  actions: {
+    create: {
+      params: {
+        name: "string",
+      },
+      async handler(ctx) {
+        try {
+          const fileName = `${Date.now()}_${ctx.params.name}.js`;
+          fs.writeFileSync(
+            path.join(this.settings.migrationsFolder, fileName),
+            MIGRATION_FILE_TEMPLATE
+          );
+          this.logSuccess(`New migration ${fileName} successfully created`);
+          return true;
+        } catch (e) {
+          this.logError(`An error occurred during migration creation: ${e.message}`);
+          return false;
+        }
+      },
+    },
+
+    async status() {
+      const migrations = await this.listMigrations();
+
+      console.table(
+        migrations.map((migration) => ({
+          name: migration.name,
+          status: migration.onlyDb
+            ? "Unknown migration applied"
+            : migration.appliedDate
+            ? "Applied"
+            : "Not applied",
+          "applied date": migration.appliedDate || "-",
+        }))
+      );
+      return true;
+    },
+
+    up: {
+      params: {
+        name: {
+          type: "string",
+          optional: true,
+        },
+        latest: {
+          type: "boolean",
+          optional: true,
+        },
+      },
+      async handler(ctx) {
+        const migrations = await this.listMigrations();
+
+        // Run for a named migration
+        if (ctx.params.name) {
+          const paramName = ctx.params.name.replace(/\.js$/, "");
+          const currentMigration = migrations.find(
+            (migration) => migration.name === paramName
+          );
+
+          if (!currentMigration) {
+            this.logError(`No migration found with name "${paramName}"`);
+            return false;
+          } else if (currentMigration.appliedDate) {
+            this.logWarn(
+              `Migration "${paramName}" is already applied. Nothing to do.`
+            );
+            return true;
+          }
+
+          if (ctx.params.latest) {
+            this.logInfo('Param --latest is ignored when a named migration is given');
+          }
+
+          return await this.internalUp(currentMigration);
+        }
+
+        const notAppliedMigrations = migrations.filter(
+          (migration) => !migration.appliedDate
+        );
+
+        if (notAppliedMigrations.length === 0) {
+          this.logWarn(
+            `All found migrations are already applied. Nothing to do.`
+          );
+          return true;
+        }
+
+        // Run all not applied migrations
+        if (ctx.params.latest) {
+          let success = true;
+          for (let currentMigration of notAppliedMigrations) {
+            if (success) {
+              success = await this.internalUp(currentMigration);
+            } else {
+              this.logInfo(
+                `Due to previous failure, migration "${currentMigration.name}" is not applied.`
+              );
+            }
+          }
+          return success;
+        } else {
+          // Run next not applied migration
+          return await this.internalUp(notAppliedMigrations[0]);
+        }
+      },
+    },
+
+    down: {
+      params: {
+        name: {
+          type: "string",
+          optional: true,
+        },
+        earliest: {
+          type: "boolean",
+          optional: true,
+        },
+        force: {
+          type: "boolean",
+          optional: true,
+        },
+      },
+      async handler(ctx) {
+        const migrations = await this.listMigrations();
+
+        // Run down for a named migration
+        if (ctx.params.name) {
+          const paramName = ctx.params.name.replace(/\.js$/, "");
+          const currentMigration = migrations.find(
+            (migration) => migration.name === paramName
+          );
+
+          if (!currentMigration) {
+            this.logError(`No migration found with name "${paramName}"`);
+            return false;
+          } else if (!currentMigration.appliedDate) {
+            this.logWarn(
+              `Migration "${paramName}" is already not applied. Nothing to do.`
+            );
+            return true;
+          }
+
+          if (ctx.params.earliest) {
+            this.logInfo('Param --earliest is ignored when a named migration is given');
+          }
+
+          return await this.internalDown(
+            currentMigration,
+            ctx.params.force || false
+          );
+        }
+
+        const appliedMigrations = migrations
+          .filter((migration) => migration.appliedDate !== null)
+          .reverse();
+
+        if (appliedMigrations.length === 0) {
+          this.logWarn(
+            `None of found migrations is already applied. Nothing to do.`
+          );
+          return true;
+        }
+
+        // Run down all applied migrations in reverse
+        if (ctx.params.earliest) {
+          let success = true;
+          for (let currentMigration of appliedMigrations) {
+            if (success) {
+              success = await this.internalDown(
+                currentMigration,
+                ctx.params.force || false
+              );
+            } else {
+              this.logInfo(
+                `Due to previous failure, migration "${currentMigration.name}" is not rollbacked.`
+              );
+            }
+          }
+          return success;
+        } else {
+          // Run previous applied migration
+          return await this.internalDown(
+            appliedMigrations[0],
+            ctx.params.force || false
+          );
+        }
+      },
+    },
+
+    clear: {
+      params: {
+        yes: {
+          type: 'boolean',
+          optional: true
+        }
+      },
+      async handler(ctx) {
+        if (!ctx.params.yes) {
+          this.logWarn('WARNING: This command will drop migration graph in database without rollbacking migrations');
+          this.logWarn('If you want to rollback all migrations, use "down --earliest" instead');
+          this.logWarn('Please relaunch this command with --yes parameter to execute it');
+          return true;
+        } else {
+          try {
+            await this.broker.call("triplestore.update", {
+              query: `DROP GRAPH <${this.settings.graphName}>`,
+            });
+            this.logSuccess('Migration graph successfully deleted');
+            return true;
+          } catch (e) {
+            this.logError(`An error occurred: ${e.message}`);
+            return false;
+          }
+        }
+      }
+    }
+  },
+};

--- a/middleware/yarn.lock
+++ b/middleware/yarn.lock
@@ -1514,9 +1514,9 @@ canonicalize@^1.0.1:
   resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
   integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
 
-"cas@git+https://github.com/joshchan/node-cas.git":
+"cas@https://github.com/joshchan/node-cas":
   version "0.0.5"
-  resolved "git+https://github.com/joshchan/node-cas.git#344a8bfba9d054e2e378adaf95b720c898ae48a2"
+  resolved "https://github.com/joshchan/node-cas#344a8bfba9d054e2e378adaf95b720c898ae48a2"
   dependencies:
     cheerio "0.19.0"
 
@@ -1720,6 +1720,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^2.15.1:
   version "2.20.3"


### PR DESCRIPTION
Hello,

Cette PR fait suite au bug remonté sur Semapps https://github.com/assemblee-virtuelle/semapps/issues/1185.  
La conclusion de la discussion étant qu'il était trop tôt d'intégrer un service de migrations dans Semapps, je me permets donc de proposer un service équivalent ici.

### Contexte

Le service s'inspire des autres solutions de migration de base de données existants (tels que https://db-migrate.readthedocs.io/en/latest/, https://knexjs.org/guide/migrations.html#migration-cli or https://phinx.org/).

Le principe est qu'à chaque opération de migration nécessaire en base de données, on crée un fichier de migration, qui contient les opérations pour migrer (up), ainsi que les opérations pour revenir à l'état précédent (down). Chaque migration appliqué est sauvegardé en base de données pour savoir l'état actuel d'exécution des migrations.

### Proposition

Un service `dbMigrations` créé ici reprend ce principe, en s'interfaçant avec Moleculer et le TriplestoreService.  
Les fichiers de migrations sont stockés dans le répertoire `middleware/migrations`.  
L'état des migrations est sauvegardé dans la base de données dans un nouveau graph nommé `http://semapps.org/migrations`.
Un CLI nommé `dbMigrate` a été ajouté répliquant les actions du service `dbMigrations` mais pouvant être lancé en parallèle ou indépendamment du middleware.

#### Création d'une nouvelle migration

Pour créer une nouvelle migration, on peut utiliser la commande `yarn run dbMigrate --name <nomDeLaMigration>`.
Celle-ci va créer un nouveau fichier js dans le dossier de migrations, préfixé par un timestamp pour pouvoir ordonner les migrations dans l'ordre chronologique.

Le contenu du fichier créé correspond à ceci : 
```js
module.exports = {
  up: async ({ query, insert, update }) => {
    /*
     * You can use 'query', 'insert' and 'update' actions from triplestore service
     * Documentation for these methods can be found here: https://semapps.org/docs/middleware/triplestore
     * Example:
     *
     * const queryResult = await query({
     *   query: `
     *     SELECT ?s ?p ?o
     *     WHERE {
     *       ?subject ?predicate ?object
     *     }
     *   `,
     * });
     */

  },
  down: async ({ query, insert, update }) => {
    /*
     * This function must undo what is done in the above "up" function.
     * If things are not undoable, it must ensure that the database will be in a coherent working state
     */

  },
};
```

#### Lister le statut des migrations

On peut lister le statut des migrations via la commande `yarn run dbMigrate status`.
Celle-ci affiche un tableau avec le nom de chaque migration trouvée (dans les fichiers et/ou dans la base de données), leur statut (`Not applied` ou `Applied`) et leur éventuelle date d'exécution pour celles appliquées.

<img width="813" alt="Capture d’écran 2023-10-30 à 22 55 35" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/5d399803-8748-4a4f-ac94-df5c5366d3d4">

#### Appliquer une migration

On peut appliquer une migration via la commande `yarn run dbMigrate up`.
- Sans aucun argument, la prochaine migration non-appliquée sera appliquée.
- Avec un argument `--name <NomDeLaMigration>`, seule cette migration sera appliquée
- Avec l'argument `--latest`, toutes les migrations non appliquées seront appliquées dans l'ordre chronologique

<img width="862" alt="Capture d’écran 2023-10-30 à 23 02 57" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/7ee8d7b4-b005-4102-ab6a-7223194dff5e">

#### Rollback une migration

On peut rollback une migration via la commande `yarn run dbMigrate down`.
- Sans aucun argument, la dernière migration appliquée sera rollback.
- Avec un argument `--name <NomDeLaMigration>`, seule cette migration sera rollback
- Avec l'argument `--earliest`, toutes les migrations appliquées seront rollback dans l'ordre anti-chronologique 
- Avec l'argument `--force`, une migration non présente dans les fichiers mais présente en base de données sera effacée (ça peut arriver si on se retrouve dans un état incohérent et qu'on veuille nettoyer la base de données)

### Première migration ajoutée

J'ai aussi profité de cette PR pour ajouter la première migration `archipelago-updateFilesType` pour permettre de migrer le type des fichiers uploadés avant la version 0.6.0.