### PR TITLE
[Minor] Prevent from querying resources after window refocus

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import { Admin, Resource, memoryStore } from 'react-admin';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { LoginPage } from '@semapps/auth-provider';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient } from 'react-query';
 
 import HomePage from './HomePage';
 import i18nProvider from './config/i18nProvider';
@@ -12,6 +13,14 @@ import theme from './config/theme';
 import * as resources from './resources';
 
 import Layout from './layout/Layout';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false
+    },
+  },
+});
 
 const App = () => (
   <StyledEngineProvider injectFirst>
@@ -28,12 +37,13 @@ const App = () => (
           loginPage={LoginPage}
           dashboard={HomePage}
           store={memoryStore()}
+          queryClient={queryClient}
         >
           {Object.entries(resources).map(([key, resource]) => (
             <Resource key={key} name={key} {...resource.config} />
           ))}
         </Admin>
-      </ThemeProvider> 
+      </ThemeProvider>
     </BrowserRouter>
   </StyledEngineProvider>
 );


### PR DESCRIPTION
Hello,

J'ai remarqué que de nombreuses requêtes étaient effectuées, non seulement au chargement des pages, mais également dès qu'on revient sur une page précédemment quittée (après un changement d'onglet de navigateur, ou simplement une perte de focus de la fenêtre). Ce mécanisme est logique pour des interfaces de type dashboard comme c'est l'objectif premier de react-admin. Cependant pour l'utilisation qui est en faite dans Archipelago, et vu l'aspect statique des données stockées, ça n'a pas de sens ici, et ça peut entraîner des téléchargements de données non-nécessaires pour les utilisateurs.

Exemple ci-dessous avec une vue "Carte" où tous les items doivent être chargés sans pagination, et un changement d'onglet. 2 requêtes Sparql lourdes sont effectuées avant le changement, puis au retour sur l'onglet, ces mêmes requêtes sont réeffectuées inutilement. _(Le fait qu'il y a deux requêtes identiques qui sont effectuées est un autre souci qui sera probablement corrigé ultérieurement)_

<img width="1680" alt="Capture d’écran 2023-11-25 à 00 57 32" src="https://github.com/assemblee-virtuelle/archipelago/assets/9048062/b84e1a2d-3810-4ba5-bf4c-8f511df0cab7">
