### PR TITLE
[Minor] Handle list permissions correctly

### DIFF
--- a/frontend/src/layout/TreeMenu/TreeMenu.js
+++ b/frontend/src/layout/TreeMenu/TreeMenu.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useResourceDefinitions, Logout, Menu, useGetIdentity, MenuItemLink, useTranslate } from "react-admin";
+import { useResourceDefinitions, Logout, Menu, useGetIdentity, MenuItemLink, useTranslate, useAuthProvider } from "react-admin";
 import { useLocation } from "react-router";
 import { useMediaQuery, Divider } from "@mui/material";
 import DefaultIcon from "@mui/icons-material/ViewList";
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import LoginIcon from '@mui/icons-material/Login';
+import { useCreateContainerUri } from "@semapps/semantic-data-provider";
 import SubMenu from "./SubMenu";
 import ResourceMenuLink from "./ResourceMenuLink";
 
@@ -16,6 +17,36 @@ const TreeMenu = () => {
     () => Object.values(resourceDefinitions),
     [resourceDefinitions]
   );
+
+  const [resourcesPermissions, setResourcesPermissions] = useState({});
+  const getCreateContainerUri = useCreateContainerUri();
+  const authProvider = useAuthProvider();
+
+  useEffect(() => {
+    const fetchPermissions = async () => {
+      const filteredResources = resources.filter(resource => resource.hasList);
+
+      const names = filteredResources.map(resource => resource.name);
+      const containersUri = filteredResources.map(resource => getCreateContainerUri(resource.name));
+
+      if (containersUri.every(uri => !uri)) {
+        return;
+      }
+
+      const permissions = await Promise.all(containersUri.map(containerUri => {
+        return authProvider.getPermissions(containerUri || {});
+      }));
+
+      const obj = names.reduce((acc, name, index) => {
+        acc[name] = permissions[index].some(p => p['acl:mode'] === 'acl:Read');
+        return acc;
+      }, {});
+
+      setResourcesPermissions(obj);
+    };
+
+    fetchPermissions();
+  }, [authProvider, resources, getCreateContainerUri]);
 
   const location = useLocation();
   const matches = location.pathname.match(/^\/([^/]+)/);
@@ -40,13 +71,13 @@ const TreeMenu = () => {
   // Calculate available categories
   const categories = useMemo(() => {
     const names = resources.reduce((categories, resource) => {
-      if (resource.options?.parent) {
+      if (resource.options?.parent && resource.hasList && resourcesPermissions[resource.name]) {
         categories.push(resource.options.parent);
       }
       return categories;
     }, []);
     return resources.filter((resource) => names.includes(resource.name));
-  }, [resources]);
+  }, [resources, resourcesPermissions]);
 
   // Open submenu of current page
   useEffect(() => {
@@ -75,13 +106,13 @@ const TreeMenu = () => {
         icon={menuRootItem.icon ? <menuRootItem.icon /> : <DefaultIcon />}
       >
         {resources
-          .filter(resource => resource.hasList && resource.options.parent === menuRootItem.name)
+          .filter(resource => resource.hasList && resourcesPermissions[resource.name] && resource.options.parent === menuRootItem.name)
           .map(resource => (
             <ResourceMenuLink key={resource.name} resource={resource} />
           ))}
       </SubMenu>
     ) : (
-      menuRootItem.hasList && (
+      menuRootItem.hasList && resourcesPermissions[menuRootItem.name] && (
         <ResourceMenuLink key={menuRootItem.name} resource={menuRootItem} />
       )
     );

--- a/frontend/src/layout/list/ListView.js
+++ b/frontend/src/layout/list/ListView.js
@@ -1,10 +1,18 @@
 import React from 'react';
-import { useListContext, Pagination } from 'react-admin';
+import { useListContext, Pagination, useResourceContext } from 'react-admin';
 import { Box } from '@mui/material';
+import { useCheckPermissions } from '@semapps/auth-provider';
+import { useCreateContainer } from '@semapps/semantic-data-provider';
 import BaseView from "../BaseView";
 
 const ListView = ({ title, children, aside, actions, pagination }) => {
   const listContext = useListContext();
+
+  const resource = useResourceContext();
+  const containerUri = useCreateContainer(resource);
+
+  useCheckPermissions(containerUri, 'list');
+
   return(
     <BaseView title={title} actions={actions} aside={aside} context={listContext}>
       <Box p={3}>


### PR DESCRIPTION
Hello,

**Contexte**

Le besoin initial de cette PR est de pouvoir masquer des éléments du menu en fonction de si l'utilisateur est connecté ou non, ou selon s'il est dans un certain groupe ou non. Par exemple, la liste des personnes peut être une page sensible qu'il n'est pas nécessaire de laisser visible à tous les utilisateurs non-connectés. Ou par exemple pour laisser seulement les admins du site pouvoir modifier les thèmes, les rôles ou les statuts.

En investiguant, j'ai remarqué que les pages de liste en général n'avait pas de permissions associées.

**Proposition**

Je propose donc cette PR dans laquelle j'ai effectué deux modifications : 

* La première pour rajouter le check des permissions sur les pages List.

* La seconde pour également masquer les ressources dont la liste n'est pas accessible du menu. La proposition ici est de requêter les permissions de chacun des éléments affichés du menu, pour savoir si on a les permissions de le voir ou pas. Ca fonctionne, mais du coup fait autant de requête acl au chargement du site, et ça ralentit l'affichage du menu... Ca m'embête un peu, mais je n'arrive pas à voir comment faire ça d'une meilleure façon. On sera de toutes façons toujours obligé de faire un appel au backend, la seule autre option serait de grouper en un seul call toutes les permissions demandées, mais ça nécessite un peu plus de travail. N'hésitez pas à me dire s'il y a une solution plus élégante à ce problème 🙏 

**Dépendances**

⚠️ Cette PR est dépendante de la PR https://github.com/assemblee-virtuelle/semapps/pull/1211 sur Semapps.