### PR TITLE
[patch] (v2.0.0) Wrong display of TabbedForm component

### DIFF
--- a/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
@@ -8,7 +8,7 @@ import Edit from "../../../../layout/edit/Edit";
 
 const ProjectEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm>
+    <TabbedForm syncWithLocation={false}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
         <TextInput source="pair:comment" fullWidth />

--- a/frontend/src/resources/Agent/Activity/Task/TaskEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Task/TaskEdit.jsx
@@ -8,7 +8,7 @@ import Edit from "../../../../layout/edit/Edit";
 
 const TaskEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm>
+    <TabbedForm syncWithLocation={false}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
         <MarkdownInput source="pair:description" fullWidth />

--- a/frontend/src/resources/Agent/Actor/Organization/OrganizationEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Organization/OrganizationEdit.jsx
@@ -16,7 +16,7 @@ import ReificationArrayInput from '../../../../common/input/ReificationArrayInpu
 
 export const OrganizationEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm>
+    <TabbedForm syncWithLocation={false}>
       <TabbedForm.Tab label="Données">
         <TextInput source="pair:label" fullWidth />
         <TextInput source="pair:comment" fullWidth />
@@ -55,7 +55,7 @@ export const OrganizationEdit = props => (
       <TabbedForm.Tab label="Relations">
         <OrganizationsInput source="pair:partnerOf" />
         <EventsInput source="pair:involvedIn" />
-        <DocumentsInput source="pair:documentedBy" />   
+        <DocumentsInput source="pair:documentedBy" />
         <CustomTreeSelectArrayInput source="pair:hasTopic" reference="Theme" label="A pour thème" broader="pair:broader" fullWidth />
       </TabbedForm.Tab>
     </TabbedForm>

--- a/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
@@ -12,7 +12,7 @@ export const PersonEdit = props => (
     transform={data => ({ ...data, 'pair:label': `${data['pair:firstName']} ${data['pair:lastName']?.toUpperCase()}` })}
     {...props}
   >
-    <TabbedForm>
+    <TabbedForm syncWithLocation={false}>
       <FormTab label="Données">
         <TextInput source="pair:firstName" fullWidth />
         <TextInput source="pair:lastName" fullWidth />

--- a/frontend/src/resources/Concept/Theme/ThemeEdit.jsx
+++ b/frontend/src/resources/Concept/Theme/ThemeEdit.jsx
@@ -15,20 +15,20 @@ export const ThemeEdit = props => {
 
   return (
     <Edit redirect="show" {...props}>
-      <TabbedForm>
+      <TabbedForm syncWithLocation={false}>
         <FormTab label="Données">
           <TextInput source="pair:label" fullWidth />
           <MarkdownInput source="pair:description" fullWidth />
         </FormTab>
         <FormTab label="Relations">
           <AgentsInput source="pair:topicOf" />
-          <CustomTreeSelectInput 
-            label="Thème Parent" 
-            source="pair:broader" 
-            reference="Theme" 
-            broader="pair:broader" 
+          <CustomTreeSelectInput
+            label="Thème Parent"
+            source="pair:broader"
+            reference="Theme"
+            broader="pair:broader"
             validate={choices(validateIds, `La selection ne peut pas être l'élément courant`)}
-            fullWidth 
+            fullWidth
           />
         </FormTab>
       </TabbedForm>

--- a/frontend/src/resources/Object/Document/DocumentEdit.jsx
+++ b/frontend/src/resources/Object/Document/DocumentEdit.jsx
@@ -7,7 +7,7 @@ import Edit from "../../../layout/edit/Edit";
 
 export const DocumentEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm>
+    <TabbedForm syncWithLocation={false}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
         <TextInput source="pair:comment" fullWidth />

--- a/frontend/src/resources/Resource/Skill/SkillEdit.jsx
+++ b/frontend/src/resources/Resource/Skill/SkillEdit.jsx
@@ -5,7 +5,7 @@ import { UsersInput, AgentsInput } from '../../../common/input';
 
 export const SkillEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm>
+    <TabbedForm syncWithLocation={false}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
       </FormTab>


### PR DESCRIPTION
Hello, 
Durant mes phases de tests et recettes de la v2, je suis tombé sur un bug embêtant lors de l'édition d'une ressource avec un formulaire tabulaire. En fait en cliquant sur "Editer", le formulaire d'édition ne s'affiche pas la première fois, il faut ensuite cliquer sur un des onglets pour qu'il s'affiche.

Je vous joins une vidéo pour visualiser.

https://github.com/assemblee-virtuelle/archipelago/assets/9048062/6abf93f9-9b02-41f0-a892-f170db426939

Ce qu'on peut voir c'est que l'url change entre le clic sur le bouton "Editer", et le clic sur un des onglets, sur le décodage de l'url. Celle-ci passe de `http://localhost:5173/Organization/http%3A%2F%2Flocalhost%3A3000%2Forganizations%2Ftest` à `http://localhost:5173/Organization/http:%2F%2Flocalhost:3000%2Forganizations%2Ftest` (noter le non-échappement du caractère `:`. Malgré plusieurs heures passées dessus, je n'ai pas réussi à comprendre exactement la source du problème. Ca semble lié à la façon dont la lib react-router-dom décode les urls, mais je n'ai pas réussi à trouver de changement précis entre les versions sur master et sur la branche v2... 

EDIT : J'ai trouvé le problème initial ici : https://github.com/remix-run/react-router/issues/11052. React-router a fait un breaking-change dans une version mineure. C'est sensé être revert sur les dernières versions mais visiblement il y a encore quelques soucis...

Dans tous les cas, ce bug renforce le fait qu'il va falloir s'atteler à la réécriture des urls pour ne plus avoir des url complètes dedans, comme mentionnés auparavant ici : https://github.com/assemblee-virtuelle/archipelago/issues/146, https://github.com/assemblee-virtuelle/semapps/issues/636 ou https://github.com/assemblee-virtuelle/semapps/issues/1222

Ma proposition de résolution est de [désactiver le routing](https://marmelab.com/react-admin/TabbedForm.html#syncwithlocation) des formulaires à onglets. Le changement est que l'url ne changera pas quand on changera d'onglet, et qu'il n'y aura plus de `/2` ou `/3` ajoutés dans l'url. Pour moi c'est presque bénéfique car le /2 ou /3 n'apportait pas grand chose, une future évolution sera plutôt, pour les formulaire qui auront toujours besoin d'onglets, de créer des routes plus compréhensives, du style `/members` par exemple.