### PR TITLE
[Minor] Simplify view imports

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,7 +12,7 @@ import dataProvider from './config/dataProvider';
 import theme from './config/theme';
 import resources from './resources';
 
-import Layout from './layout/Layout';
+import { Layout } from './layout';
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/common/CreateOrImport.jsx
+++ b/frontend/src/common/CreateOrImport.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TextInput, useResourceContext } from 'react-admin';
 import { CreateOrImportForm } from '@semapps/interop-components';
 import { useDataModel } from '@semapps/semantic-data-provider';
-import Create from "../layout/create/Create";
+import { Create } from '../layout';
 
 const CreateOrImport = props => {
   const resource = useResourceContext({});

--- a/frontend/src/layout/create/Create.tsx
+++ b/frontend/src/layout/create/Create.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import { CreateActions, CreateBase, CreateProps } from 'react-admin';
-import CreateView from "./CreateView";
+import { CreateView } from '../index';
 
 const Create = ({ title, actions, children, ...rest }: PropsWithChildren<CreateProps>) => (
   <CreateBase {...rest}>

--- a/frontend/src/layout/create/CreateView.tsx
+++ b/frontend/src/layout/create/CreateView.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, ReactElement } from 'react';
 import { useCreateContext } from 'react-admin';
 import { useCheckPermissions } from '@semapps/auth-provider';
 import { useCreateContainerUri } from '@semapps/semantic-data-provider';
-import BaseView from "../BaseView";
+import { BaseView } from '../index';
 
 type Props = {
   title?: string | ReactElement;

--- a/frontend/src/layout/edit/Edit.tsx
+++ b/frontend/src/layout/edit/Edit.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { EditBase, EditProps } from 'react-admin';
-import { EditActionsWithPermissions } from "@semapps/auth-provider";
-import EditView from "./EditView";
+import { EditActionsWithPermissions } from '@semapps/auth-provider';
+import { EditView } from '../index';
 
 const Edit = ({ title, actions, children, ...rest }: PropsWithChildren<EditProps>) => (
   <EditBase mutationMode="pessimistic" {...rest}>

--- a/frontend/src/layout/edit/EditView.tsx
+++ b/frontend/src/layout/edit/EditView.tsx
@@ -1,8 +1,7 @@
 import React, { PropsWithChildren, ReactElement } from 'react';
 import { RaRecord, useEditContext, useGetRecordRepresentation, useResourceContext } from 'react-admin';
 import { useCheckPermissions } from '@semapps/auth-provider';
-import { EditToolbarWithPermissions } from '@semapps/auth-provider';
-import BaseView from '../BaseView';
+import { BaseView } from '../index';
 
 type Props = {
   title?: string | ReactElement;
@@ -22,9 +21,7 @@ const EditView = ({ title, actions, children }: PropsWithChildren<Props>) => {
 
   return (
     <BaseView title={title || recordTitle} actions={actions}>
-      {React.cloneElement(children as ReactElement, {
-        toolbar: <EditToolbarWithPermissions />
-      })}
+      {children}
     </BaseView>
   );
 };

--- a/frontend/src/layout/index.ts
+++ b/frontend/src/layout/index.ts
@@ -1,0 +1,14 @@
+export { default as Layout } from './Layout';
+export { default as BaseView } from './BaseView';
+
+export {default as Create } from './create/Create';
+export {default as CreateView } from './create/CreateView';
+
+export {default as Edit } from './edit/Edit';
+export {default as EditView } from './edit/EditView';
+
+export {default as List } from './list/List';
+export {default as ListView } from './list/ListView';
+
+export {default as Show } from './show/Show';
+export {default as ShowView } from './show/ShowView';

--- a/frontend/src/layout/list/List.tsx
+++ b/frontend/src/layout/list/List.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { ListBase, ListProps, TopToolbar } from 'react-admin';
-import ListView from './ListView';
 import { ListActionsWithPermissions } from '@semapps/auth-provider';
 import { ViewsButtons } from '@semapps/list-components';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { ListView } from '../index';
 
 const ActionsBox = styled(Box)(({ theme }) => ({
   display: 'flex',

--- a/frontend/src/layout/list/ListView.tsx
+++ b/frontend/src/layout/list/ListView.tsx
@@ -1,9 +1,9 @@
 import React, { PropsWithChildren, ReactElement } from 'react';
 import { useListContext, Pagination } from 'react-admin';
 import { Box } from '@mui/material';
-import BaseView from '../BaseView';
 import { useCheckPermissions } from '@semapps/auth-provider';
 import { useCreateContainerUri } from '@semapps/semantic-data-provider';
+import { BaseView } from '../index';
 
 type Props = {
   title?: string | ReactElement;

--- a/frontend/src/layout/show/Show.tsx
+++ b/frontend/src/layout/show/Show.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ShowBase, ShowProps } from 'react-admin';
 import { ShowActionsWithPermissions } from '@semapps/auth-provider';
-import ShowView from './ShowView';
+import {ShowView} from '../index';
 
 const Show = ({ title, actions, children, ...rest }: ShowProps) => (
   <ShowBase {...rest}>

--- a/frontend/src/layout/show/ShowView.tsx
+++ b/frontend/src/layout/show/ShowView.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, ReactElement } from 'react';
 import { RaRecord, useGetRecordRepresentation, useResourceContext, useShowContext } from 'react-admin';
 import { Box } from '@mui/material';
 import { useCheckPermissions } from '@semapps/auth-provider';
-import BaseView from '../BaseView';
+import { BaseView } from '../index';
 
 type Props = {
   title?: string | ReactElement;

--- a/frontend/src/resources/Agent/Activity/Event/EventCreate.jsx
+++ b/frontend/src/resources/Agent/Activity/Event/EventCreate.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { CreateOrImportForm } from "@semapps/interop-components";
 import { useResourceContext, SimpleForm } from "react-admin";
-import Create from "../../../../layout/create/Create";
+import { Create } from "../../../../layout";
 import EventForm from "./EventForm";
 import config from '../../../../config/config';
 

--- a/frontend/src/resources/Agent/Activity/Event/EventEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Event/EventEdit.jsx
@@ -1,11 +1,12 @@
 import React from "react";
-import Edit from "../../../../layout/edit/Edit";
-import EventForm from "./EventForm";
 import { SimpleForm } from "react-admin";
+import { EditToolbarWithPermissions } from "@semapps/auth-provider";
+import { Edit } from "../../../../layout";
+import EventForm from "./EventForm";
 
 const EventEdit = (props) => (
   <Edit redirect="show" {...props}>
-    <SimpleForm spacing={2} useFlexGap>
+    <SimpleForm spacing={2} useFlexGap toolbar={<EditToolbarWithPermissions />}>
       <EventForm />
     </SimpleForm>
   </Edit>

--- a/frontend/src/resources/Agent/Activity/Event/EventList.jsx
+++ b/frontend/src/resources/Agent/Activity/Event/EventList.jsx
@@ -7,7 +7,7 @@ import frLocale from '@fullcalendar/core/locales/fr';
 import ListIcon from '@mui/icons-material/List';
 import EventIcon from '@mui/icons-material/Event';
 import EventFilterSidebar from './EventFilterSidebar';
-import List from "../../../../layout/list/List";
+import { List } from '../../../../layout';
 
 const EventList = props => (
   <MultiViewsList

--- a/frontend/src/resources/Agent/Activity/Event/EventShow.jsx
+++ b/frontend/src/resources/Agent/Activity/Event/EventShow.jsx
@@ -6,7 +6,7 @@ import { GridList, ChipList } from '@semapps/list-components';
 import { MapField } from '@semapps/geo-components';
 import { MarkdownField } from '../../../../common/field';
 import { Hero, MainList, SideList } from '../../../../common/list';
-import Show from "../../../../layout/show/Show";
+import { Show } from '../../../../layout';
 
 const EventShow = props => (
   <Show {...props}>

--- a/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
@@ -4,11 +4,12 @@ import { MarkdownInput } from '@semapps/markdown-components';
 import { ActorsInput, DocumentsInput, ThemesInput, ResourcesInput } from '../../../../common/input';
 import { ImageInput } from '@semapps/input-components';
 import { ReferenceInput } from '@semapps/input-components';
-import Edit from "../../../../layout/edit/Edit";
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
+import { Edit } from '../../../../layout';
 
 const ProjectEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm syncWithLocation={false}>
+    <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
         <TextInput source="pair:comment" fullWidth />

--- a/frontend/src/resources/Agent/Activity/Project/ProjectList.jsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectList.jsx
@@ -3,7 +3,7 @@ import ProjectFilterSidebar from './ProjectFilterSidebar';
 import { Avatar } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import SimpleList from "../../../../common/list/SimpleList";
-import List from "../../../../layout/list/List";
+import { List } from '../../../../layout';
 
 const ProjectList = props => (
   <List aside={<ProjectFilterSidebar />} {...props}>

--- a/frontend/src/resources/Agent/Activity/Project/ProjectShow.jsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectShow.jsx
@@ -6,7 +6,7 @@ import { ChipList, GridList } from '@semapps/list-components';
 import DescriptionIcon from '@mui/icons-material/Description';
 import { MarkdownField } from '../../../../common/field';
 import { Hero, MainList, SideList } from '../../../../common/list';
-import Show from "../../../../layout/show/Show";
+import { Show } from '../../../../layout';
 
 const ProjectShow = props => (
   <Show {...props}>

--- a/frontend/src/resources/Agent/Activity/Task/TaskEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Task/TaskEdit.jsx
@@ -3,12 +3,13 @@ import { FormTab, TextInput, SelectInput, TabbedForm } from 'react-admin';
 import { ActorsInput, ThemesInput, TasksInput, SkillsInput, DocumentsInput, ActivitiesInput } from '../../../../common/input';
 import { ReferenceInput } from '@semapps/input-components';
 import { MarkdownInput } from '@semapps/markdown-components';
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { DateTimeInput } from "../../../../common/input";
-import Edit from "../../../../layout/edit/Edit";
+import { Edit } from '../../../../layout';
 
 const TaskEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm syncWithLocation={false}>
+    <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
         <MarkdownInput source="pair:description" fullWidth />

--- a/frontend/src/resources/Agent/Activity/Task/TaskList.jsx
+++ b/frontend/src/resources/Agent/Activity/Task/TaskList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DateField } from 'react-admin';
 import { Avatar } from '@mui/material';
 import TaskIcon from '@mui/icons-material/PlaylistAddCheck';
-import List from "../../../../layout/list/List";
+import { List } from '../../../../layout';
 import TaskFilterSidebar from './TaskFilterSidebar';
 import SimpleList from "../../../../common/list/SimpleList";
 

--- a/frontend/src/resources/Agent/Activity/Task/TaskShow.jsx
+++ b/frontend/src/resources/Agent/Activity/Task/TaskShow.jsx
@@ -5,7 +5,7 @@ import { AvatarWithLabelField, ReferenceArrayField, SeparatedListField } from '@
 import { GridList } from '@semapps/list-components';
 import { MarkdownField } from '../../../../common/field';
 import { Hero, MainList, SideList } from '../../../../common/list';
-import Show from "../../../../layout/show/Show";
+import { Show } from '../../../../layout';
 
 const TaskShow = props => (
   <Show {...props}>

--- a/frontend/src/resources/Agent/Actor/Group/GroupEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Group/GroupEdit.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { SimpleForm, TextInput, ImageField } from 'react-admin';
 import { ImageInput } from '@semapps/input-components';
 import { MarkdownInput } from '@semapps/markdown-components';
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { UsersInput, EventsInput, ThemesInput, DocumentsInput } from '../../../../common/input';
-import Edit from "../../../../layout/edit/Edit";
+import { Edit } from '../../../../layout';
 
 export const GroupEdit = props => (
   <Edit redirect="show" {...props}>
-    <SimpleForm>
+    <SimpleForm toolbar={<EditToolbarWithPermissions />}>
       <TextInput source="pair:label" fullWidth />
       <TextInput source="pair:comment" fullWidth />
       <MarkdownInput source="pair:description" fullWidth />

--- a/frontend/src/resources/Agent/Actor/Group/GroupList.jsx
+++ b/frontend/src/resources/Agent/Actor/Group/GroupList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Avatar } from '@mui/material';
 import GroupIcon from '@mui/icons-material/Group';
-import List from "../../../../layout/list/List";
+import { List } from '../../../../layout';
 import SimpleList from "../../../../common/list/SimpleList";
 
 const GroupList = props => (

--- a/frontend/src/resources/Agent/Actor/Group/GroupShow.jsx
+++ b/frontend/src/resources/Agent/Actor/Group/GroupShow.jsx
@@ -5,7 +5,7 @@ import { AvatarWithLabelField, QuickAppendReferenceArrayField, ReferenceArrayFie
 import { ChipList, GridList } from '@semapps/list-components';
 import { MarkdownField } from '../../../../common/field';
 import { Hero, MainList, SideList } from '../../../../common/list';
-import Show from "../../../../layout/show/Show";
+import { Show } from '../../../../layout';
 
 const GroupShow = props => (
   <Show {...props}>

--- a/frontend/src/resources/Agent/Actor/Organization/OrganizationEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Organization/OrganizationEdit.jsx
@@ -9,14 +9,15 @@ import {
 } from 'react-admin';
 import { ReferenceInput, ImageInput } from '@semapps/input-components';
 import { MarkdownInput } from '@semapps/markdown-components';
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { OrganizationsInput, EventsInput, DocumentsInput, LocationInput } from '../../../../common/input';
-import Edit from "../../../../layout/edit/Edit";
+import { Edit } from '../../../../layout';
 import CustomTreeSelectArrayInput from '../../../../common/input/TreeComponent/CustomTreeSelectArrayInput';
 import MembershipAssociationInput from '../../../../common/input/MembershipAssociationInput';
 
 export const OrganizationEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm syncWithLocation={false}>
+    <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
       <TabbedForm.Tab label="Données">
         <TextInput source="pair:label" fullWidth />
         <TextInput source="pair:comment" fullWidth />

--- a/frontend/src/resources/Agent/Actor/Organization/OrganizationList.jsx
+++ b/frontend/src/resources/Agent/Actor/Organization/OrganizationList.jsx
@@ -7,7 +7,7 @@ import ListIcon from '@mui/icons-material/List';
 import HomeIcon from '@mui/icons-material/Home';
 import OrganizationFilterSidebar from './OrganizationFilterSidebar';
 import SimpleList from "../../../../common/list/SimpleList";
-import List from "../../../../layout/list/List";
+import { List } from '../../../../layout';
 
 const OrganizationList = props => (
   <MultiViewsList

--- a/frontend/src/resources/Agent/Actor/Organization/OrganizationShow.jsx
+++ b/frontend/src/resources/Agent/Actor/Organization/OrganizationShow.jsx
@@ -16,7 +16,7 @@ import ForumIcon from '@mui/icons-material/Forum';
 import VideocamOutlinedIcon from '@mui/icons-material/VideocamOutlined';
 import { MarkdownField } from '../../../../common/field';
 import { Hero, MainList, SideList } from '../../../../common/list';
-import Show from "../../../../layout/show/Show";
+import { Show } from '../../../../layout';
 import MembershipAssociationField from "../../../../common/field/MembershipAssociationField";
 
 const domainMapping = {

--- a/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { ImageField, TabbedForm, TextInput, FormTab } from 'react-admin';
 import { MarkdownInput } from '@semapps/markdown-components';
 import { ImageInput } from '@semapps/input-components';
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { ActivitiesInput, LocationInput, SkillsInput, ThemesInput } from '../../../../common/input';
-import Edit from "../../../../layout/edit/Edit";
+import { Edit } from '../../../../layout';
 import MembershipAssociationInput from '../../../../common/input/MembershipAssociationInput';
 
 export const PersonEdit = props => (
@@ -12,7 +13,7 @@ export const PersonEdit = props => (
     transform={data => ({ ...data, 'pair:label': `${data['pair:firstName']} ${data['pair:lastName']?.toUpperCase()}` })}
     {...props}
   >
-    <TabbedForm syncWithLocation={false}>
+    <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
       <FormTab label="Données">
         <TextInput source="pair:firstName" fullWidth />
         <TextInput source="pair:lastName" fullWidth />

--- a/frontend/src/resources/Agent/Actor/Person/PersonList.jsx
+++ b/frontend/src/resources/Agent/Actor/Person/PersonList.jsx
@@ -9,7 +9,7 @@ import PersonIcon from '@mui/icons-material/Person';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import PersonFilterSidebar from './PersonFilterSidebar';
 import SimpleList from "../../../../common/list/SimpleList";
-import List from "../../../../layout/list/List";
+import { List } from '../../../../layout';
 
 const PersonList = props => (
   <MultiViewsList

--- a/frontend/src/resources/Agent/Actor/Person/PersonShow.jsx
+++ b/frontend/src/resources/Agent/Actor/Person/PersonShow.jsx
@@ -6,7 +6,7 @@ import { ChipList } from '@semapps/list-components';
 import { MapField } from '@semapps/geo-components';
 import { MarkdownField } from '../../../../common/field';
 import { Hero, MainList, SideList } from '../../../../common/list';
-import Show from "../../../../layout/show/Show";
+import { Show } from '../../../../layout';
 import MembershipAssociationField from '../../../../common/field/MembershipAssociationField';
 
 const PersonShow = props => (

--- a/frontend/src/resources/Concept/MembershipRole/RoleCreate.jsx
+++ b/frontend/src/resources/Concept/MembershipRole/RoleCreate.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SimpleForm, TextInput } from 'react-admin';
-import Create from "../../../layout/create/Create";
+import { Create } from '../../../layout';
 
 const RoleCreate = props => (
   <Create {...props}>

--- a/frontend/src/resources/Concept/MembershipRole/RoleEdit.jsx
+++ b/frontend/src/resources/Concept/MembershipRole/RoleEdit.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { SimpleForm, TextInput } from 'react-admin';
-import Edit from "../../../layout/edit/Edit";
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
+import { Edit } from '../../../layout';
 
 export const RoleEdit = props => (
   <Edit {...props}>
-    <SimpleForm>
+    <SimpleForm toolbar={<EditToolbarWithPermissions />}>
       <TextInput source="pair:label" fullWidth />
     </SimpleForm>
   </Edit>

--- a/frontend/src/resources/Concept/MembershipRole/RoleList.jsx
+++ b/frontend/src/resources/Concept/MembershipRole/RoleList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Avatar } from '@mui/material';
 import FavoriteBorderIcon from '@mui/icons-material/Class';
 import SimpleList from "../../../common/list/SimpleList";
-import List from "../../../layout/list/List";
+import { List } from '../../../layout';
 
 const RoleList = props => (
   <List {...props}>

--- a/frontend/src/resources/Concept/Status/StatusCreate.jsx
+++ b/frontend/src/resources/Concept/Status/StatusCreate.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SimpleForm, TextInput, SelectArrayInput } from 'react-admin';
-import Create from "../../../layout/create/Create";
+import { Create } from '../../../layout';
 
 const StatusCreate = props => (
   <Create {...props}>

--- a/frontend/src/resources/Concept/Status/StatusEdit.jsx
+++ b/frontend/src/resources/Concept/Status/StatusEdit.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { SimpleForm, TextInput } from 'react-admin';
-import Edit from "../../../layout/edit/Edit";
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
+import { Edit } from '../../../layout';
 
 export const ThemeEdit = props => (
   <Edit {...props}>
-    <SimpleForm>
+    <SimpleForm toolbar={<EditToolbarWithPermissions />}>
       <TextInput source="pair:label" fullWidth />
     </SimpleForm>
   </Edit>

--- a/frontend/src/resources/Concept/Status/StatusList.jsx
+++ b/frontend/src/resources/Concept/Status/StatusList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import SimpleList from "../../../common/list/SimpleList";
-import List from "../../../layout/list/List";
+import { List } from '../../../layout';
 
 const StatusList = props => (
   <List {...props}>

--- a/frontend/src/resources/Concept/Theme/ThemeCreate.jsx
+++ b/frontend/src/resources/Concept/Theme/ThemeCreate.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Create from "../../../layout/create/Create";
+import { Create } from '../../../layout';
 import { LexiconImportForm, fetchWikidata } from "@semapps/interop-components";
 
 const ThemeCreate = (props) => (

--- a/frontend/src/resources/Concept/Theme/ThemeEdit.jsx
+++ b/frontend/src/resources/Concept/Theme/ThemeEdit.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { FormTab, TabbedForm, TextInput, useGetList, useGetRecordId, choices } from 'react-admin';
 import { MarkdownInput } from '@semapps/markdown-components';
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { AgentsInput } from '../../../common/input';
-import Edit from "../../../layout/edit/Edit";
+import { Edit } from '../../../layout';
 import CustomTreeSelectInput from '../../../common/input/TreeComponent/CustomTreeSelectInput';
 
 export const ThemeEdit = props => {
@@ -15,7 +16,7 @@ export const ThemeEdit = props => {
 
   return (
     <Edit redirect="show" {...props}>
-      <TabbedForm syncWithLocation={false}>
+      <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
         <FormTab label="Données">
           <TextInput source="pair:label" fullWidth />
           <MarkdownInput source="pair:description" fullWidth />

--- a/frontend/src/resources/Concept/Theme/ThemeList.jsx
+++ b/frontend/src/resources/Concept/Theme/ThemeList.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import List from "../../../layout/list/List";
+import { List } from '../../../layout';
 import TreeList from '../../../common/list/TreeList';
 
 const ThemeList = props => (

--- a/frontend/src/resources/Concept/Theme/ThemeShow.jsx
+++ b/frontend/src/resources/Concept/Theme/ThemeShow.jsx
@@ -4,7 +4,7 @@ import { Grid } from '@mui/material';
 import { ReferenceArrayField } from '@semapps/field-components';
 import { MarkdownField } from '../../../common/field';
 import { MainList, SideList } from '../../../common/list';
-import Show from "../../../layout/show/Show";
+import { Show } from '../../../layout';
 
 const ThemeShow = props => (
   <Show {...props}>

--- a/frontend/src/resources/Concept/Type/TypeCreate.jsx
+++ b/frontend/src/resources/Concept/Type/TypeCreate.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SimpleForm, TextInput, SelectArrayInput } from 'react-admin';
-import Create from "../../../layout/create/Create";
+import { Create } from '../../../layout';
 
 const TypeCreate = props => (
   <Create {...props}>

--- a/frontend/src/resources/Concept/Type/TypeEdit.jsx
+++ b/frontend/src/resources/Concept/Type/TypeEdit.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { SimpleForm, TextInput } from 'react-admin';
-import Edit from "../../../layout/edit/Edit";
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
+import { Edit } from '../../../layout';
 
 export const ThemeEdit = props => (
   <Edit {...props}>
-    <SimpleForm>
+    <SimpleForm toolbar={<EditToolbarWithPermissions />}>
       <TextInput source="pair:label" fullWidth />
     </SimpleForm>
   </Edit>

--- a/frontend/src/resources/Concept/Type/TypeList.jsx
+++ b/frontend/src/resources/Concept/Type/TypeList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import StyleIcon from '@mui/icons-material/Style';
 import SimpleList from "../../../common/list/SimpleList";
-import List from "../../../layout/list/List";
+import { List } from '../../../layout';
 
 const TypeList = props => (
   <List {...props}>

--- a/frontend/src/resources/Idea/IdeaEdit.jsx
+++ b/frontend/src/resources/Idea/IdeaEdit.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { SimpleForm, TextInput, SelectInput } from 'react-admin';
 import { MarkdownInput } from '@semapps/markdown-components';
 import { ReferenceInput } from '@semapps/input-components';
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { ActorsInput, ActivitiesInput } from '../../common/input';
-import Edit from "../../layout/edit/Edit";
+import { Edit } from '../../layout';
 
 const IdeaEdit = props => (
   <Edit redirect="show" {...props}>
-    <SimpleForm>
+    <SimpleForm toolbar={<EditToolbarWithPermissions />}>
       <TextInput source="pair:label" fullWidth />
       <TextInput source="pair:comment" fullWidth />
       <MarkdownInput source="pair:description" fullWidth />

--- a/frontend/src/resources/Idea/IdeaList.jsx
+++ b/frontend/src/resources/Idea/IdeaList.jsx
@@ -3,7 +3,7 @@ import IdeaFilterSidebar from './IdeaFilterSidebar';
 import { Avatar } from '@mui/material';
 import IdeaIcon from '@mui/icons-material/EmojiObjects';
 import SimpleList from "../../common/list/SimpleList";
-import List from "../../layout/list/List";
+import { List } from '../../layout';
 
 const IdeaList = props => (
   <List aside={<IdeaFilterSidebar />} {...props}>

--- a/frontend/src/resources/Idea/IdeaShow.jsx
+++ b/frontend/src/resources/Idea/IdeaShow.jsx
@@ -4,7 +4,7 @@ import { Grid } from '@mui/material';
 import { AvatarWithLabelField, ReferenceArrayField, SeparatedListField } from '@semapps/field-components';
 import { GridList } from '@semapps/list-components';
 import { MarkdownField } from '../../common/field';
-import Show from "../../layout/show/Show";
+import { Show } from '../../layout';
 import { Hero, MainList, SideList } from '../../common/list';
 
 const IdeaShow = props => (

--- a/frontend/src/resources/Object/Document/DocumentEdit.jsx
+++ b/frontend/src/resources/Object/Document/DocumentEdit.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { FormTab, SelectInput, TabbedForm, TextInput, ImageField } from 'react-admin';
 import { ReferenceInput, ImageInput } from '@semapps/input-components';
 import { MarkdownInput } from '@semapps/markdown-components';
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { AgentsInput } from '../../../common/input';
-import Edit from "../../../layout/edit/Edit";
+import { Edit } from '../../../layout';
 
 export const DocumentEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm syncWithLocation={false}>
+    <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
         <TextInput source="pair:comment" fullWidth />

--- a/frontend/src/resources/Object/Document/DocumentList.jsx
+++ b/frontend/src/resources/Object/Document/DocumentList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DescriptionIcon from '@mui/icons-material/Description';
 import SimpleList from "../../../common/list/SimpleList";
-import List from "../../../layout/list/List";
+import { List } from '../../../layout';
 
 const DocumentList = props => (
   <List {...props}>

--- a/frontend/src/resources/Object/Document/DocumentShow.jsx
+++ b/frontend/src/resources/Object/Document/DocumentShow.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { SingleFieldList, ChipField, ImageField } from 'react-admin';
 import { Grid, Typography } from '@mui/material';
 import { ReferenceArrayField } from '@semapps/field-components';
-import Show from "../../../layout/show/Show";
+import { Show } from '../../../layout';
 import { MarkdownField } from '../../../common/field';
 import { MainList, SideList } from '../../../common/list';
 

--- a/frontend/src/resources/Page/PageCreate.jsx
+++ b/frontend/src/resources/Page/PageCreate.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SimpleForm, TextInput } from 'react-admin';
-import Create from "../../layout/create/Create";
+import { Create } from '../../layout';
 
 const PageCreate = props => (
   <Create {...props}>

--- a/frontend/src/resources/Page/PageEdit.jsx
+++ b/frontend/src/resources/Page/PageEdit.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { SimpleForm, TextInput } from 'react-admin';
 import { MarkdownInput, useLoadLinks } from '@semapps/markdown-components';
-import Edit from "../../layout/edit/Edit";
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
+import { Edit } from '../../layout';
 
 export const PageEdit = props => {
   const loadLinks = useLoadLinks('Page', 'semapps:title');
   return (
     <Edit redirect="show" {...props}>
-      <SimpleForm>
+      <SimpleForm toolbar={<EditToolbarWithPermissions />}>
         <TextInput source="semapps:title" fullWidth />
         <MarkdownInput source="semapps:content" loadSuggestions={loadLinks} suggestionTriggerCharacters="[" fullWidth />
       </SimpleForm>

--- a/frontend/src/resources/Page/PageList.jsx
+++ b/frontend/src/resources/Page/PageList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Avatar } from '@mui/material';
 import DescriptionIcon from '@mui/icons-material/Description';
 import SimpleList from "../../common/list/SimpleList";
-import List from "../../layout/list/List";
+import { List } from '../../layout';
 
 const PageList = props => (
   <List {...props}>

--- a/frontend/src/resources/Page/PageShow.jsx
+++ b/frontend/src/resources/Page/PageShow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MarkdownField } from '../../common/field';
 import { MainList } from '../../common/list';
-import Show from "../../layout/show/Show";
+import { Show } from '../../layout';
 
 const PageShow = props => (
   <Show {...props}>

--- a/frontend/src/resources/Resource/Skill/SkillEdit.jsx
+++ b/frontend/src/resources/Resource/Skill/SkillEdit.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { FormTab, TextInput, TabbedForm } from 'react-admin';
-import Edit from "../../../layout/edit/Edit";
+import { EditToolbarWithPermissions } from '@semapps/auth-provider';
+import { Edit } from '../../../layout';
 import { UsersInput, AgentsInput } from '../../../common/input';
 
 export const SkillEdit = props => (
   <Edit redirect="show" {...props}>
-    <TabbedForm syncWithLocation={false}>
+    <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
       <FormTab label="Données">
         <TextInput source="pair:label" fullWidth />
       </FormTab>

--- a/frontend/src/resources/Resource/Skill/SkillList.jsx
+++ b/frontend/src/resources/Resource/Skill/SkillList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PanToolIcon from '@mui/icons-material/PanTool';
 import SimpleList from "../../../common/list/SimpleList";
-import List from "../../../layout/list/List";
+import { List } from '../../../layout';
 
 const SkillList = props => (
   <List {...props}>

--- a/frontend/src/resources/Resource/Skill/SkillShow.jsx
+++ b/frontend/src/resources/Resource/Skill/SkillShow.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, Typography } from '@mui/material';
 import { AvatarWithLabelField, QuickAppendReferenceArrayField, ReferenceArrayField } from '@semapps/field-components';
 import { GridList, ChipList } from '@semapps/list-components';
-import Show from "../../../layout/show/Show";
+import { Show } from '../../../layout';
 import { SideList } from '../../../common/list';
 
 const SkillShow = props => (


### PR DESCRIPTION
Hello,

Je propose cette PR pour modifier la façon dont les imports vers les différents composants de vues (list, show, edit, create) en fonction des ressources. Jusqu'à maintenant, tous les fichiers étaient importés directement, ce qui pose des problèmes dans le cas où on veut par exemple customiser la vue de base (BaseView), ou une des vues précédemment citées. 

Ce que je propose ici, c'est de créer un fichier index à la racine du dossier layout, qui réexporte tous les composants de vues inclus dans le layout, et de changer tous les imports pour tous composants (d'où le nombre important de fichiers modifiés). Ainsi, si on veut changer un de ces composants par un autre, les modifications seront beaucoup plus simples.

Cela prépare également le terrain pour proposer plusieurs layouts par défaut dans Archipelago.

J'en ai profité également pour virer le React.cloneElement qui restait dans la base de code vu que c'est plutôt une mauvaise pratique de développement React dans ce cas précis (je refactorerai sûrement par la suite en créant un composant SimpleForm commun une fois que tous les formulaires de ressources seront harmonisés).

--

Sans feedback contradictoire, je mergerai cette PR à la fin de la semaine prochaine