### PR TITLE
[Patch] 193 - Fix referenced attributes on edit pages

### DIFF
--- a/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { ImageField, SelectInput, TextInput, TabbedForm, FormTab } from 'react-admin';
+import { ImageField, SelectInput, TextInput, TabbedForm, FormTab, ReferenceInput } from 'react-admin';
 import { MarkdownInput } from '@semapps/markdown-components';
 import { ActorsInput, DocumentsInput, ThemesInput, ResourcesInput } from '../../../../common/input';
 import { ImageInput } from '@semapps/input-components';
-import { ReferenceInput } from '@semapps/input-components';
 import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { Edit } from '../../../../layout';
 

--- a/frontend/src/resources/Agent/Activity/Task/TaskEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Task/TaskEdit.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { FormTab, TextInput, SelectInput, TabbedForm } from 'react-admin';
+import { FormTab, TextInput, SelectInput, TabbedForm, ReferenceInput } from 'react-admin';
 import { ActorsInput, ThemesInput, TasksInput, SkillsInput, DocumentsInput, ActivitiesInput } from '../../../../common/input';
-import { ReferenceInput } from '@semapps/input-components';
 import { MarkdownInput } from '@semapps/markdown-components';
 import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { DateTimeInput } from "../../../../common/input";

--- a/frontend/src/resources/Agent/Actor/Organization/OrganizationEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Organization/OrganizationEdit.jsx
@@ -6,8 +6,9 @@ import {
   ImageField,
   SimpleFormIterator,
   ArrayInput,
+  ReferenceInput
 } from 'react-admin';
-import { ReferenceInput, ImageInput } from '@semapps/input-components';
+import { ImageInput } from '@semapps/input-components';
 import { MarkdownInput } from '@semapps/markdown-components';
 import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { OrganizationsInput, EventsInput, DocumentsInput, LocationInput } from '../../../../common/input';

--- a/frontend/src/resources/Idea/IdeaEdit.jsx
+++ b/frontend/src/resources/Idea/IdeaEdit.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { SimpleForm, TextInput, SelectInput } from 'react-admin';
+import { SimpleForm, TextInput, SelectInput, ReferenceInput } from 'react-admin';
 import { MarkdownInput } from '@semapps/markdown-components';
-import { ReferenceInput } from '@semapps/input-components';
 import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { ActorsInput, ActivitiesInput } from '../../common/input';
 import { Edit } from '../../layout';

--- a/frontend/src/resources/Object/Document/DocumentEdit.jsx
+++ b/frontend/src/resources/Object/Document/DocumentEdit.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { FormTab, SelectInput, TabbedForm, TextInput, ImageField } from 'react-admin';
-import { ReferenceInput, ImageInput } from '@semapps/input-components';
+import { FormTab, SelectInput, TabbedForm, TextInput, ImageField, ReferenceInput } from 'react-admin';
+import { ImageInput } from '@semapps/input-components';
 import { MarkdownInput } from '@semapps/markdown-components';
 import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { AgentsInput } from '../../../common/input';


### PR DESCRIPTION
Hello,

Je propose cette PR pour corriger #193.

Le problème venait que le composant ReferenceInput avait été surchargé dans Semapps.
Celui-ci semblait manipuler la valeur de l'attribut d'une façon un peu bizarre, le transformant en tableau (alors qu'il ne s'agiit pas d'un ReferenceArrayInput). Les requêtes vers le DataProvider étaient donc incorrecte puisqu'un getMany(ids=[[valeur]]) était effectué au lieu d'un getManu(ids=[valeur]).

J'ai remis celui de base proposé par react-admin. J'ai testé amplement les ajouts/modifications/suppressions de statuts et types et je n'ai pas compris pourquoi cette surcharge avait été faite. Quoiqu'il en soit, ça corrige bien le bug.