### PR TITLE
[Patch] 200 - Mobile form toolbar hidden behind bottom navigation

### DIFF
--- a/frontend/src/config/theme.js
+++ b/frontend/src/config/theme.js
@@ -10,12 +10,12 @@ const theme = createTheme({
     grey: { main: '#e0e0e0' },
     background: {
       default: '#efefef',
-    }
+    },
   },
   typography: {
     details: {
-      fontSize: 8
-    }
+      fontSize: 8,
+    },
   },
   components: {
     RaChipField: {
@@ -24,19 +24,19 @@ const theme = createTheme({
           marginLeft: 0,
           marginTop: 0,
           marginRight: 8,
-          marginBottom: 8
-        }
-      }
+          marginBottom: 8,
+        },
+      },
     },
     RaShow: {
       styleOverrides: {
         card: {
           padding: 25,
           [defaultTheme.breakpoints.down('sm')]: {
-            padding: 15
-          }
-        }
-      }
+            padding: 15,
+          },
+        },
+      },
     },
     RaList: {
       styleOverrides: {
@@ -45,40 +45,49 @@ const theme = createTheme({
           [defaultTheme.breakpoints.down('sm')]: {
             padding: 15,
             paddingTop: 0,
-            marginTop: -8
-          }
-        }
-      }
+            marginTop: -8,
+          },
+        },
+      },
+    },
+    RaToolbar: {
+      styleOverrides: {
+        root: {
+          [`&.RaToolbar-mobileToolbar`]: {
+            position: 'static',
+          },
+        },
+      },
     },
     RaListToolbar: {
       styleOverrides: {
         toolbar: {
-          paddingLeft: '0 !important'
-        }
-      }
+          paddingLeft: '0 !important',
+        },
+      },
     },
     RaSingleFieldList: {
       styleOverrides: {
         root: {
           marginTop: 0,
-          marginBottom: 0
-        }
-      }
+          marginBottom: 0,
+        },
+      },
     },
     RaAutocompleteArrayInput: {
       styleOverrides: {
         chipContainerFilled: {
           '& .serverName': {
-            display: 'none'
-          }
-        }
-      }
+            display: 'none',
+          },
+        },
+      },
     },
     RaMenuItemLink: {
       styleOverrides: {
         root: ({ theme }) => ({
           '&.RaMenuItemLink-active': {
-              borderLeft: `3px solid ${theme.palette.primary.main}`,
+            borderLeft: `3px solid ${theme.palette.primary.main}`,
           },
         }),
       },
@@ -86,38 +95,38 @@ const theme = createTheme({
     MuiTab: {
       styleOverrides: {
         root: {
-          minWidth: 160
+          minWidth: 160,
         },
         labelIcon: {
-          paddingTop: 0
-        }
-      }
+          paddingTop: 0,
+        },
+      },
     },
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
           backgroundColor: '#efefef',
         },
-      }
+      },
     },
     MuiAutocomplete: {
       styleOverrides: {
         inputRoot: {
           paddingTop: 12,
-          paddingBottom: 5
-        }
-      }
+          paddingBottom: 5,
+        },
+      },
     },
     MuiCard: {
       styleOverrides: {
         root: {
           '@media print': {
-            boxShadow: 'none !important'
-          }
-        }
-      }
-    }
-  }
+            boxShadow: 'none !important',
+          },
+        },
+      },
+    },
+  },
 });
 
 export default theme;


### PR DESCRIPTION
Hello,

Petite PR de correction d'un bug sur le layout TopMenu au niveau des formulaires de création/édition.
Les boutons sauvegarder / supprimer passaient sous la barre de navigation mobile, car son positionnement dans React-Admin est fixed. J'ai corrigé le souci en forçant la position en static.

La différence de comportement désormais est qu'il est nécessaire de scroller tout en bas du formulaire en vue mobile pour pouvoir sauvegarder.

PS : Beaucoup de changements de style dans le fichier modifié car il n'était pas conforme au linter. La modification se situe L53-60.

**Layout leftMenu**

Avant : 
<img width="252" alt="Capture d’écran 2024-11-12 à 22 13 33" src="https://github.com/user-attachments/assets/a30d217d-4eb7-4a06-9f3d-0c44f7489b68">

Après
<img width="252" alt="Capture d’écran 2024-11-12 à 22 13 53" src="https://github.com/user-attachments/assets/d7c8ee0f-d5ce-4f27-aad7-e589d64ef20d">

** Layout topMenu**

Avant : 
<img width="252" alt="Capture d’écran 2024-11-12 à 22 13 05" src="https://github.com/user-attachments/assets/116905ee-9337-4060-a9e5-5735ca9aa22c">

Après : 
<img width="253" alt="Capture d’écran 2024-11-12 à 22 12 45" src="https://github.com/user-attachments/assets/7cf141f6-a6b9-4e43-9028-bc487eb164c2">

