### PR TITLE
[Minor] Add footer option for topMenu layout

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -3,6 +3,7 @@
 You can choose the UI layout of Archipelago by updating the `layout` configuration in the `/frontend/src/config/config.ts` file.
 
 Structure of the `layout` configuration attribute is as below:
+
 ```js
 {
   ...
@@ -28,6 +29,7 @@ This layout has a collapsible menu on the left side and a search form on the top
 
 There is currently no options for this layout.
 It can be configured as below:
+
 ```js
 {
   layout: {
@@ -45,19 +47,20 @@ This layout has a main horizontal menu in its top bar, and secondary dropdown me
 
 Layout options are listed in the table below. All options are optional.
 
-| Property           | Type                                        | Default           | Description                                                                                                                                         |
-|--------------------|---------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `sideBarPlacement` | `left` or `right`                           | `left`            | Indicates if the filter side bar should be located on the left or right side of the main content
-| `logo`             | `string` or `{ url: string; alt: string; }` | no logo           | Customizes app logo on the left of the top bar. If no value, logo is not displayed. If a string is provided, it must be a valid relative path for the logo image. If an object is provided, it should contains `url` attribute for the relative path of the image, and `alt` attribute for accessibility alternative text
-| `title`            | `boolean` or a React component              | default app title | Customizes app title in the top bar. If no value, or `true`, default app title is displayed. If value is `false`, no title is displayed. If a React component is provided, it is displayed instead of text title
-| `mainMenu`         | array of `MainMenuItem` objects             | empty menu        | Customizes main horizontal menu in the top bar. See below for the MainMenuItem object details. It is recommanded to not have more than 4 main menu items.
+| Property           | Type                                        | Default           | Description                                                                                                                                                                                                                                                                                                               |
+| ------------------ | ------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sideBarPlacement` | `left` or `right`                           | `left`            | Indicates if the filter side bar should be located on the left or right side of the main content                                                                                                                                                                                                                          |
+| `logo`             | `string` or `{ url: string; alt: string; }` | no logo           | Customizes app logo on the left of the top bar. If no value, logo is not displayed. If a string is provided, it must be a valid relative path for the logo image. If an object is provided, it should contains `url` attribute for the relative path of the image, and `alt` attribute for accessibility alternative text |
+| `title`            | `boolean` or a React component              | default app title | Customizes app title in the top bar. If no value, or `true`, default app title is displayed. If value is `false`, no title is displayed. If a React component is provided, it is displayed instead of text title                                                                                                          |
+| `mainMenu`         | array of `MainMenuItem` objects             | empty menu        | Customizes main horizontal menu in the top bar. See below for the MainMenuItem object details. It is recommanded to not have more than 4 main menu items.                                                                                                                                                                 |
+| `footer`           | React component                             | -                 | Customizes app footer with a custom component. Default is no footer.
 
 MainMenuItem object properties:
 
-| Property      | Type               | Default      | Description                                                                                                                                         |
-|---------------|--------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `label`       | `string`           | **required** | Menu item label
-| `link`        | `string`           | **required** | Menu item url
-| `icon`        | `SvgIconComponent` | **required** | Menu item icon. It should be a MaterialUI icon component (see https://mui.com/material-ui/material-icons/)
-| `mobileLabel` | `string`           | -            | If menu item label is too long for bottom navigation mobile view, it can be customized here for a shorter label
-| `resource`    | `string`           | -            | Resource associated to menu item. If provided, it hides the resource in the secondary dropdown menu, and colors the bottom navigation item if current url matches
+| Property      | Type               | Default      | Description                                                                                                                                                       |
+| ------------- | ------------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label`       | `string`           | **required** | Menu item label                                                                                                                                                   |
+| `link`        | `string`           | **required** | Menu item url                                                                                                                                                     |
+| `icon`        | `SvgIconComponent` | **required** | Menu item icon. It should be a MaterialUI icon component (see https://mui.com/material-ui/material-icons/)                                                        |
+| `mobileLabel` | `string`           | -            | If menu item label is too long for bottom navigation mobile view, it can be customized here for a shorter label                                                   |
+| `resource`    | `string`           | -            | Resource associated to menu item. If provided, it hides the resource in the secondary dropdown menu, and colors the bottom navigation item if current url matches |

--- a/frontend/src/common/layout/list/ListView.tsx
+++ b/frontend/src/common/layout/list/ListView.tsx
@@ -1,9 +1,26 @@
 import React, { PropsWithChildren, ReactElement } from 'react';
-import { useListContext, Pagination } from 'react-admin';
+import { useListContext, Pagination, CreateButton, useResourceDefinition, usePermissions } from 'react-admin';
 import { Box } from '@mui/material';
-import { useCheckPermissions } from '@semapps/auth-provider';
+import { styled } from '@mui/material/styles';
+import { Permissions, useCheckPermissions } from '@semapps/auth-provider';
 import { useCreateContainerUri } from '@semapps/semantic-data-provider';
 import { useLayoutContext } from '../../../layouts/LayoutContext';
+
+const FloatingCreateButtonBox = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  right: 10,
+  height: '100%',
+  pointerEvents: 'none',
+  '& .RaCreateButton-floating': {
+    position: 'sticky',
+    top: 'calc(100% - 56px - 62px)',
+    pointerEvents: 'auto',
+  },
+  [theme.breakpoints.up('md')]: {
+    display: 'none',
+  },
+}));
 
 type Props = {
   title?: string | ReactElement;
@@ -21,10 +38,23 @@ const ListView = ({ title, children, aside, actions, pagination }: PropsWithChil
 
   const Layout = useLayoutContext();
 
+  const resourceDefinition = useResourceDefinition();
+  const { permissions } = usePermissions(createContainerUri) as { permissions: Permissions };
+
   return (
     <Layout.BaseView title={title ?? listContext.defaultTitle} actions={actions} aside={aside}>
-      <Box p={3}>{children}</Box>
+      <Box px={Layout.name === 'leftMenu' ? 3 : 0} py={3}>
+        {children}
+      </Box>
       {pagination === false ? null : pagination || <Pagination />}
+
+      {resourceDefinition.hasCreate &&
+        permissions &&
+        permissions.some((p) => ['acl:Append', 'acl:Write', 'acl:Control'].includes(p['acl:mode'])) && (
+          <FloatingCreateButtonBox>
+            <CreateButton />
+          </FloatingCreateButtonBox>
+        )}
     </Layout.BaseView>
   );
 };

--- a/frontend/src/config/theme.js
+++ b/frontend/src/config/theme.js
@@ -126,6 +126,24 @@ const theme = createTheme({
         },
       },
     },
+    MuiCssBaseline: {
+      styleOverrides: () => ({
+        body: {
+          [theme.breakpoints.up('md')]: {
+            'overscrollBehaviorY': 'none'
+          },
+        },
+      }),
+    },
+    RaCreateButton: {
+      styleOverrides: {
+        root: {
+          '.MuiToolbar-root &.RaCreateButton-floating': {
+            display: 'none',
+          }
+        }
+      }
+    }
   },
 });
 

--- a/frontend/src/layouts/topMenu/AppBar.tsx
+++ b/frontend/src/layouts/topMenu/AppBar.tsx
@@ -22,7 +22,7 @@ const AppBar = () => {
   const logo = layout.options.logo;
 
   return (
-    <MuiAppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+    <MuiAppBar position="sticky" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
       <Toolbar>
         {logo && (
           <Box sx={{ marginRight: { xs: 0, lg: 1 } }}>

--- a/frontend/src/layouts/topMenu/Aside.tsx
+++ b/frontend/src/layouts/topMenu/Aside.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useState } from 'react';
-import { Box, Drawer, Fab, Toolbar, useMediaQuery } from '@mui/material';
+import { Box, Drawer, Fab, useMediaQuery } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import TuneIcon from '@mui/icons-material/Tune';
 import { useLayoutContext } from '../LayoutContext';
@@ -11,9 +11,25 @@ const ContentBox = styled(Box)(({ theme }) => ({
   minWidth: asideWidth,
   padding: 16,
   boxSizing: 'border-box',
+  position: 'sticky',
+  height: 'calc(100vh - 64px)',
+  top: '64px',
+  overflow: 'auto',
   [theme.breakpoints.down('md')]: {
     paddingBottom: 56 + 16,
+    height: 'calc(100vh - 56px)',
+    top: '56px',
   },
+}));
+
+const FloatingBox = styled(Box)(() => ({
+  position: 'absolute',
+  height: '100%',
+  '& .MuiFab-root': {
+    left: 10,
+    position: 'sticky',
+    top: 'calc(100% - 56px - 56px)'
+  }
 }));
 
 const Aside = ({ children }: PropsWithChildren) => {
@@ -27,19 +43,16 @@ const Aside = ({ children }: PropsWithChildren) => {
   return (
     <>
       {isMobile && (
-        <Fab
-          variant="extended"
-          color="primary"
-          sx={{
-            position: 'fixed',
-            bottom: 64,
-            left: 10,
-          }}
-          onClick={() => setAsideOpen(true)}
-        >
-          <TuneIcon sx={{ mr: 1 }} />
-          Filtres
-        </Fab>
+        <FloatingBox>
+          <Fab
+            variant="extended"
+            color="primary"
+            onClick={() => setAsideOpen(true)}
+          >
+            <TuneIcon sx={{ mr: 1 }} />
+            Filtres
+          </Fab>
+        </FloatingBox>
       )}
       <Drawer
         sx={{
@@ -48,6 +61,10 @@ const Aside = ({ children }: PropsWithChildren) => {
           '& .MuiDrawer-paper': {
             width: asideWidth,
             boxSizing: 'border-box',
+            position: {xs: 'fixed', md: 'absolute'},
+            overflow: 'unset',
+            left: (!side || side === 'left') ? 0 : 'auto',
+            right: (!side || side === 'left') ? 'auto' : 0,
           },
         }}
         variant={isMobile ? 'temporary' : 'permanent'}
@@ -55,7 +72,6 @@ const Aside = ({ children }: PropsWithChildren) => {
         anchor={side}
         onClose={() => setAsideOpen(false)}
       >
-        <Toolbar />
         <ContentBox>{children}</ContentBox>
       </Drawer>
     </>

--- a/frontend/src/layouts/topMenu/BaseView.tsx
+++ b/frontend/src/layouts/topMenu/BaseView.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, ReactNode } from 'react';
-import { Grid, Typography, Box, useMediaQuery } from '@mui/material';
-import { styled, useTheme } from '@mui/material/styles';
+import { Grid, Typography, Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import { LayoutOptions } from './index';
 import { useLayoutContext } from '../LayoutContext';
 
@@ -33,16 +33,12 @@ type Props = {
 
 const BaseView = ({ title, actions, aside, children }: PropsWithChildren<Props>) => {
   const layout = useLayoutContext<LayoutOptions>();
-
-  const side = layout.options.sideBarPlacement || 'left';
-  const asideWidth = '300px';
-
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const side = layout.options.sideBarPlacement;
 
   return (
     <>
-      <Box sx={{ [side === 'left' ? 'marginLeft' : 'marginRight']: aside && !isMobile ? asideWidth : 0 }}>
+      {(!side || side === 'left') && aside}
+      <Box sx={{ flex: 1 }}>
         <Grid container sx={{ paddingTop: 2 }}>
           <Grid item xs={9} sm={8}>
             <Title variant="h4" color="primary" component="h1">
@@ -57,7 +53,7 @@ const BaseView = ({ title, actions, aside, children }: PropsWithChildren<Props>)
           </Grid>
         </Grid>
       </Box>
-      {aside}
+      {side === 'right' && aside}
     </>
   );
 };

--- a/frontend/src/layouts/topMenu/Layout.tsx
+++ b/frontend/src/layouts/topMenu/Layout.tsx
@@ -2,15 +2,36 @@ import React, { PropsWithChildren } from 'react';
 import AppBar from './AppBar';
 import { Box } from '@mui/material';
 import BottomNavigation from './BottomNavigation';
+import { useLayoutContext } from '../LayoutContext';
+import { LayoutOptions } from '.';
 
 const Layout = ({ children }: PropsWithChildren) => {
+  const layout = useLayoutContext<LayoutOptions>();
+
   return (
-    <Box>
+    <Box sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      minHeight: '100vh',
+      paddingBottom: { xs: '56px', md: 0 }
+    }}>
       <AppBar />
 
-      <Box component={"main"} sx={{ paddingX: { xs: 1, md: 2 }, marginTop: '64px', marginBottom: { xs: 8, md: 0 } }}>
+      <Box
+        component={'main'}
+        sx={{
+          paddingX: { xs: 1, md: 2 },
+          paddingBottom: { xs: 5, md: 0 },
+          marginBottom: { xs: 1, md: 0 },
+          display: 'flex',
+          flex: 1,
+          position: 'relative',
+        }}
+      >
         {children}
       </Box>
+
+      {layout.options.footer?.()}
 
       <BottomNavigation />
     </Box>

--- a/frontend/src/layouts/topMenu/index.ts
+++ b/frontend/src/layouts/topMenu/index.ts
@@ -14,7 +14,8 @@ export type LayoutOptions = {
       mobileLabel?: string;
       link: string;
       icon: SvgIconComponent;
-    }[]
+    }[];
+    footer: () => ReactNode;
   }>;
 };
 


### PR DESCRIPTION
Hello,

Je propose cette PR pour rajouter la possibilité d'avoir de définir un footer dans le layout `topMenu`.
Il suffit de définir son composant dans l'option "footer" du layout.

Exemple : 

<img width="1680" alt="Capture d’écran 2024-11-26 à 01 08 26" src="https://github.com/user-attachments/assets/ec34b3af-33a8-4cef-b37a-c9258fec05fd">

<img width="410" alt="Capture d’écran 2024-11-28 à 22 17 01" src="https://github.com/user-attachments/assets/790b5ed8-1151-4924-9023-d607ebd3bf62">


J'ai un peu galéré à traiter tous les cas possible pour ne pas engendrer de bugs d'affichage sur les différentes pages, mais peut-être qu'il reste des cas que je n'ai pas trouvé, n'hésitez pas à les faire remonter ici si vous utilisez cette fonctionnalité.