### PR TITLE
[Minor] 199 - Change default resources list fetching to LDP containers

### DIFF
--- a/frontend/src/resources/Agent/Activity/Activity.jsx
+++ b/frontend/src/resources/Agent/Activity/Activity.jsx
@@ -27,6 +27,7 @@ const resource = {
     types: ['pair:Project', 'pair:Event', 'pair:Task'],
     list: {
       servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'pair:label'

--- a/frontend/src/resources/Agent/Activity/Event/index.js
+++ b/frontend/src/resources/Agent/Activity/Event/index.js
@@ -20,7 +20,8 @@ const resource = {
   dataModel: {
     types: ['pair:Event'],
     list: {
-      servers: '@default'
+      servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'pair:label'

--- a/frontend/src/resources/Agent/Activity/Project/index.js
+++ b/frontend/src/resources/Agent/Activity/Project/index.js
@@ -20,7 +20,8 @@ const resource = {
   dataModel: {
     types: ['pair:Project'],
     list: {
-      servers: '@default'
+      servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'pair:label'

--- a/frontend/src/resources/Agent/Activity/Task/index.js
+++ b/frontend/src/resources/Agent/Activity/Task/index.js
@@ -20,7 +20,8 @@ const resource = {
   dataModel: {
     types: ['pair:Task'],
     list: {
-      servers: '@default'
+      servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'pair:label'

--- a/frontend/src/resources/Agent/Actor/Actor.jsx
+++ b/frontend/src/resources/Agent/Actor/Actor.jsx
@@ -21,6 +21,7 @@ const resource = {
     types: ['pair:Organization', 'pair:Person', 'pair:Group'],
     list: {
       servers: '@default',
+      fetchContainer: true,
     }
   },
   translations: {

--- a/frontend/src/resources/Agent/Actor/Group/index.js
+++ b/frontend/src/resources/Agent/Actor/Group/index.js
@@ -20,7 +20,8 @@ const resource = {
   dataModel: {
     types: ['pair:Group'],
     list: {
-      servers: '@default'
+      servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'pair:label'

--- a/frontend/src/resources/Agent/Actor/Organization/index.js
+++ b/frontend/src/resources/Agent/Actor/Organization/index.js
@@ -21,6 +21,7 @@ const resource = {
     types: ['pair:Organization'],
     list: {
       servers: '@default',
+      fetchContainer: true,
       forceArray: ['pair:organizationOfMembership', 'pair:homePage']
     },
     fieldsMapping: {

--- a/frontend/src/resources/Agent/Actor/Person/index.js
+++ b/frontend/src/resources/Agent/Actor/Person/index.js
@@ -19,6 +19,7 @@ const resource = {
     types: ['pair:Person'],
     list: {
       servers: '@default',
+      fetchContainer: true,
       forceArray: ['pair:actorOfMembership']
     },
     fieldsMapping: {

--- a/frontend/src/resources/Agent/Agent.jsx
+++ b/frontend/src/resources/Agent/Agent.jsx
@@ -23,6 +23,7 @@ const resource = {
     types: ['pair:Project', 'pair:Organization', 'pair:Person', 'pair:Group', 'pair:Event'],
     list: {
       servers: '@default',
+      fetchContainer: true,
     }
   }
 };

--- a/frontend/src/resources/Concept/Concept.js
+++ b/frontend/src/resources/Concept/Concept.js
@@ -11,6 +11,7 @@ const resource = {
     types: ['pair:Theme'],
     list: {
       servers: '@default',
+      fetchContainer: true,
     }
   },
   translations: {

--- a/frontend/src/resources/Concept/MembershipRole/index.js
+++ b/frontend/src/resources/Concept/MembershipRole/index.js
@@ -19,6 +19,7 @@ const resource = {
     types: ['pair:MembershipRole'],
     list: {
       servers: '@default',
+      fetchContainer: true,
       blankNodes: []
     },
     fieldsMapping: {

--- a/frontend/src/resources/Concept/Status/index.js
+++ b/frontend/src/resources/Concept/Status/index.js
@@ -28,6 +28,7 @@ const resource = {
     ],
     list: {
       servers: '@default',
+      fetchContainer: true,
       blankNodes: []
     },
     fieldsMapping: {

--- a/frontend/src/resources/Concept/Theme/index.js
+++ b/frontend/src/resources/Concept/Theme/index.js
@@ -21,6 +21,7 @@ const resource = {
     types: ['pair:Theme'],
     list: {
       servers: '@default',
+      fetchContainer: true,
       blankNodes: []
     },
     fieldsMapping: {

--- a/frontend/src/resources/Concept/Type/index.js
+++ b/frontend/src/resources/Concept/Type/index.js
@@ -36,6 +36,7 @@ const resource = {
     ],
     list: {
       servers: '@default',
+      fetchContainer: true,
       blankNodes: []
     },
     fieldsMapping: {

--- a/frontend/src/resources/Idea/index.js
+++ b/frontend/src/resources/Idea/index.js
@@ -19,7 +19,8 @@ const resource = {
   dataModel: {
     types: ['pair:Idea'],
     list: {
-      servers: '@default'
+      servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'pair:label'

--- a/frontend/src/resources/Object/Document/index.js
+++ b/frontend/src/resources/Object/Document/index.js
@@ -19,7 +19,8 @@ const resource = {
   dataModel: {
     types: ['pair:Document'],
     list: {
-      servers: '@default'
+      servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'pair:label'

--- a/frontend/src/resources/Object/Object.js
+++ b/frontend/src/resources/Object/Object.js
@@ -11,6 +11,7 @@ const resource = {
     types: ['pair:Document'],
     list: {
       servers: '@default',
+      fetchContainer: true,
     }
   },
   translations: {

--- a/frontend/src/resources/Page/index.js
+++ b/frontend/src/resources/Page/index.js
@@ -19,7 +19,8 @@ const resource = {
   dataModel: {
     types: ['semapps:Page'],
     list: {
-      servers: '@default'
+      servers: '@default',
+      fetchContainer: true,
     },
     fieldsMapping: {
       title: 'semapps:title'

--- a/frontend/src/resources/Resource/Resource.jsx
+++ b/frontend/src/resources/Resource/Resource.jsx
@@ -22,6 +22,7 @@ const resource = {
     types: ['pair:Skill'],
     list: {
       servers: '@default',
+      fetchContainer: true,
     }
   },
   translations: {

--- a/frontend/src/resources/Resource/Skill/index.js
+++ b/frontend/src/resources/Resource/Skill/index.js
@@ -21,6 +21,7 @@ const resource = {
     types: ['pair:Skill'],
     list: {
       servers: '@default',
+      fetchContainer: true,
       blankNodes: []
     },
     fieldsMapping: {


### PR DESCRIPTION
Hello,

Je propose cette modification de la façon dont les ressources sont requêtées suite au ticket #199.

Auparavant, les listes de ressources étaient requêtées via une requête via l'endpoint SPARQL, ce qui pouvait proposer des soucis de : 
- Performances (avec la gestion des permissions dans la requête, certaines peuvent aller jusqu'à >30s d'exécution)
- Sécurité (le type et la structure de la base de données sont révélées côté frontend)
- Architecture (on couple le frontend avec la façon dont sont stockées les données côté backend, rendant plus difficile des opérations de changement de structure ou de base de données si jamais)