### PR TITLE
[Minor] Better user management

### DIFF
--- a/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
@@ -1,46 +1,77 @@
 import React from 'react';
-import { ImageField, TabbedForm, TextInput, FormTab } from 'react-admin';
+import { ImageField, TabbedForm, TextInput, FormTab, SaveButton, Toolbar as RaToolbar, useGetIdentity, required, useRedirect, useLogout } from 'react-admin';
 import { MarkdownInput } from '@semapps/markdown-components';
 import { ImageInput } from '@semapps/input-components';
-import { EditToolbarWithPermissions } from '@semapps/auth-provider';
+import { DeleteButtonWithPermissions } from '@semapps/auth-provider';
 import { ActivitiesInput, LocationInput, SkillsInput, ThemesInput } from '../../../../common/input';
 import { Edit } from '../../../../common/layout';
 import MembershipAssociationInput from '../../../../common/input/MembershipAssociationInput';
 
-export const PersonEdit = props => (
-  <Edit
-    redirect="show"
-    transform={data => ({ ...data, 'pair:label': `${data['pair:firstName']} ${data['pair:lastName']?.toUpperCase()}` })}
-    {...props}
-  >
-    <TabbedForm syncWithLocation={false} toolbar={<EditToolbarWithPermissions />}>
-      <FormTab label="Données">
-        <TextInput source="pair:firstName" fullWidth />
-        <TextInput source="pair:lastName" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
-        <MarkdownInput source="pair:description" fullWidth />
-        <LocationInput source="pair:hasLocation" fullWidth />
-        <ImageInput source="image" accept="image/*">
-          <ImageField source="src" />
-        </ImageInput>
-      </FormTab>
-      <FormTab label="Rôles">
-        <MembershipAssociationInput
-          source="pair:actorOfMembership"
-          referenceInputProps={{
-            reference: "Organization",
-            source: "pair:membershipOrganization"
-          }}
-          label="Organisation"
-        />
-      </FormTab>
-      <FormTab label="Relations">
-        <ActivitiesInput source="pair:involvedIn" />
-        <SkillsInput source="pair:offers" />
-        <ThemesInput source="pair:hasTopic" />
-      </FormTab>
-    </TabbedForm>
-  </Edit>
-);
+export const PersonEdit = (props) => {
+  const redirect = useRedirect();
+  const { data: identityData, refetch: refetchIdentity } = useGetIdentity();
+  const logout = useLogout();
+
+  return (
+    <Edit
+      mutationOptions={{
+        onSuccess: (record) => {
+          refetchIdentity();
+          redirect('show', 'Person', record.id);
+        }
+      }}
+      transform={data => ({ ...data, 'pair:label': `${data['pair:firstName']} ${(data['pair:lastName'] || '')?.toUpperCase()}` })}
+      {...props}
+    >
+      <TabbedForm syncWithLocation={false} toolbar={
+        <RaToolbar sx={{ justifyContent: 'space-between' }}>
+          <SaveButton />
+          <DeleteButtonWithPermissions
+            confirmTitle="Suppression du compte utilisateur"
+            confirmContent={<div>
+              <p>Êtes-vous sûr·e de vouloir supprimer ce compte utilisateur ?</p>
+              <p><strong>Cette action est irréversible.</strong></p>
+            </div>}
+            mutationOptions={{
+              onSuccess: (deletedRecord) => {
+                if (identityData?.id === deletedRecord?.id) {
+                  logout();
+                } else {
+                  redirect('list', 'Person');
+                }
+              }
+            }}
+          />
+        </RaToolbar>
+      }>
+        <FormTab label="Données">
+          <TextInput source="pair:firstName" fullWidth validate={[required()]} />
+          <TextInput source="pair:lastName" fullWidth />
+          <TextInput source="pair:comment" fullWidth />
+          <MarkdownInput source="pair:description" fullWidth />
+          <LocationInput source="pair:hasLocation" fullWidth />
+          <ImageInput source="image" accept="image/*">
+            <ImageField source="src" />
+          </ImageInput>
+        </FormTab>
+        <FormTab label="Rôles">
+          <MembershipAssociationInput
+            source="pair:actorOfMembership"
+            referenceInputProps={{
+              reference: "Organization",
+              source: "pair:membershipOrganization"
+            }}
+            label="Organisation"
+          />
+        </FormTab>
+        <FormTab label="Relations">
+          <ActivitiesInput source="pair:involvedIn" />
+          <SkillsInput source="pair:offers" />
+          <ThemesInput source="pair:hasTopic" />
+        </FormTab>
+      </TabbedForm>
+    </Edit>
+  );
+};
 
 export default PersonEdit;


### PR DESCRIPTION
Hello, 

Comme mentionné sur [la feuille de route](https://github.com/assemblee-virtuelle/archipelago/discussions/198), je propose ici quelques modification dans la gestion des comptes utilisateurs.

#### Contexte

Actuellement, quand un utilisateur se crée un compte via un fournisseur d'identité OIDC, l'identifiant de son utilisateur créé (webId) correspond à la première partie de l'email associé au compte, suffixé d'un numéro si des utilisateurs existent déjà avec cet identifiant.

Exemple : 
 - Email : prenom.nom@gmail.com => WebId : http://site.domain/users/prenom.nom
 - Email : contact@monsiteperso.com => WebId : http://site.domain/users/contact
 - Email : prenom.nom@laposte.net => WebId : http://site.domain/users/prenom.nom1

Ce fonctionnement a pour gros inconvénient de dévoiler via le webId de l'utilisateur son email (si on suppose un nom de domaine couramment utilisé de type gmail, hotmail, etc.). De plus, sémantiquement parlant, l'identifiant peut ne rien avoir en relation avec l'identité de l'utilisateur (exemple des email en contact@...).

Ensuite, concernant les données insérées en base de données lors de la création d'un compte utilisateur, on obtient les triples suivants : 

```sparql 
# Dans le dataset "settings"
1 <urn:AuthAccount:3a9c1f7c-c3e2-4f58-8ce6-5baeee8795cf> <http://semapps.org/ns/core#email> prenom.nom@gmail.com
2 <urn:AuthAccount:3a9c1f7c-c3e2-4f58-8ce6-5baeee8795cf> <http://semapps.org/ns/core#username> prenom.nom
3 <urn:AuthAccount:3a9c1f7c-c3e2-4f58-8ce6-5baeee8795cf> <http://semapps.org/ns/core#webId> http://localhost:3000/users/prenom.nom
4 <urn:AuthAccount:3a9c1f7c-c3e2-4f58-8ce6-5baeee8795cf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://semapps.org/ns/core#AuthAccount>

# Dans le dataset "localData"
1 <http://localhost:3000/users/prenom.nom> <http://xmlns.com/foaf/0.1/familyName> Nom
2 <http://localhost:3000/users/prenom.nom> <http://xmlns.com/foaf/0.1/name> Prénom
3 <http://localhost:3000/users/prenom.nom> <http://xmlns.com/foaf/0.1/email> prenom.nom@gmail.com
4 <http://localhost:3000/users/prenom.nom> <http://xmlns.com/foaf/0.1/nick> prenom.nom
5 <http://localhost:3000/users/prenom.nom> <http://purl.org/dc/terms/created> 2023-11-22T01:23:50.391Z
6 <http://localhost:3000/users/prenom.nom> <http://purl.org/dc/terms/modified> 2023-11-22T01:23:53.238Z
7 <http://localhost:3000/users/prenom.nom> <http://virtual-assembly.org/ontologies/pair#label> Prénom NOM
8 <http://localhost:3000/users/prenom.nom> <http://virtual-assembly.org/ontologies/pair#firstName> Prénom
9 <http://localhost:3000/users/prenom.nom> <http://virtual-assembly.org/ontologies/pair#lastName> Nom
10 <http://localhost:3000/users/prenom.nom> <http://virtual-assembly.org/ontologies/pair#e-mail> prenom.nom@gmail.com
11 <http://localhost:3000/users/prenom.nom> <https://www.w3.org/ns/activitystreams#preferredUsername> prenom.nom
```

Pour rappel, seul le dataset "localData" est accessible via l'endpoint Sparql et les requêtes LDP.

On peut remarquer plusieurs choses : 
- Les données de prénom/nom/email sont dupliquées entre les ontologies FOAF et PAIR.
- L'email est enregistré dans l'ontologie PAIR mais non modifiable dans l'interface.
- Les prénom/nom/email enregistrés dans l'ontologie FOAF ne sont pas modifiables dans l'interface.

En plus des incohérences que ça peut apporter, cela favorise la fuite de données personnelles (nom, email) via les interfaces de requêtes.

Seules les données de l'ontologie PAIR sont utilisées dans l'interface (affichage/édition du profil, lien avec les autres ressources).

Enfin, lors de la suppression d'un compte utilisateur, certaines données ne sont pas supprimées (celles du dataset "settings"), alors que les autres sont bien supprimées (transformées en tombstone). Cela pose problème puisqu'on garde en mémoire des données personnelles sans consentement de l'utilisateur qui pour lui a bien supprimé son compte. De plus, en laissant ces informations en base, cela empêche de créer un nouveau compte avec le même email.

#### Proposition apportée

Concernant le premier point (le webId), il est proposé dans cette PR que celui-ci soit généré via un uuid unique (via l'ajout de la propriété `webIdSelection: ['uuid']` dans l'authService, où il suffit de renseigner un tableau de taille non-nulle ne contenant pas les champs venant du fournisseur d'identité, ainsi le webId ne trouvant aucune information, il prendra un uuid par défaut). Une première version de cette correction avait été proposée sur Semapps ici https://github.com/assemblee-virtuelle/semapps/pull/1126 mais n'avait pas été mergée.

Concernant le second point, en filtrant l'objet venant du fournisseur d'identité (via webIdSelection) pour ne fournir aucun des attributs nécessaires à l'établissement d'une ressource de type FOAF, celle-ci n'est dès lors plus créée systématiquement.

Pour la création de la ressource avec les attributs PAIR, je propose de supprimer la création par défaut de l'email de l'utilisateur, sachant que celui-ci n'est pas éditable dans l'interface (il ne peut donc pas par exemple choisir dans l'interface de le renseigner ou pas).

Concernant le dernier point, un hook a été rajouté pour supprimer également le compte utilisateur lors de la suppression de la ressource.

Plusieurs autres modifications sont proposées également : 
- La possibilité de ne pas renseigner de nom de famille pour juste s'identifier avec un prénom/pseudo (qui lui est obligatoire)
- L'amélioration de la popup de confirmation de suppression de compte pour la rendre plus lisible
- La déconnexion forcée de l'utilisateur lors de la suppression de son compte
- Le rechargement de l'identité de l'utilisateur lors de l'édition de son profil

:)