### PR TITLE
[Minor] Users migrations

### DIFF
--- a/middleware/migrations/1733442498449_archipelago-anonymizeUsersWebId.js
+++ b/middleware/migrations/1733442498449_archipelago-anonymizeUsersWebId.js
@@ -1,0 +1,152 @@
+const crypto = require('crypto');
+
+module.exports = {
+  up: async ({ query, insert, update, call }) => {
+
+    const usersWithoutUUID = await query({
+      query: `
+        PREFIX core: <http://semapps.org/ns/core#>
+
+        SELECT ?s ?o
+        WHERE {
+          ?s core:webId ?o .
+          FILTER NOT EXISTS {
+            FILTER regex(str(?o), "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")
+          }
+        }
+      `,
+      dataset: 'settings',
+    });
+
+    for (let user of usersWithoutUUID) {
+      const uuid = crypto.randomUUID();
+      const oldWebId = user.o.value;
+      let newWebId = `${oldWebId.split('/').slice(0, -1).join('/')}/${uuid}`;
+      const suffixes = ['', '/inbox', '/outbox', '/followers', '/following', '/liked'];
+
+      console.log(`Found webId: ${oldWebId}, replacing by ${newWebId}`);
+
+      // Update settings => webId
+      await update({
+        query: `
+          DELETE {
+            ?s ?p "${oldWebId}" .
+          }
+          INSERT {
+            ?s ?p "${newWebId}" .
+          }
+          WHERE {
+            ?s ?p "${oldWebId}" .
+          }
+        `,
+        dataset: 'settings',
+      });
+
+      for (let suffix of suffixes) {
+        console.log(`Updating for ${oldWebId}${suffix}...`);
+
+        // Update localData => all rows
+        await update({
+          query: `
+            DELETE {
+              <${oldWebId}${suffix}> ?p ?o .
+              ?s ?p2 <${oldWebId}${suffix}> .
+            }
+            INSERT {
+              <${newWebId}${suffix}> ?p ?o .
+              ?s ?p2 <${newWebId}${suffix}> .
+            }
+            WHERE {
+              {
+                <${oldWebId}${suffix}> ?p ?o .
+              }
+              UNION
+              {
+                ?s ?p2 <${oldWebId}${suffix}> .
+              }
+            }
+          `,
+          webId: 'system',
+        });
+
+        // Update specific activityPub preferredUsername
+        await update({
+          query: `
+            DELETE {
+              <${newWebId}> <https://www.w3.org/ns/activitystreams#preferredUsername> ?o .
+            }
+            INSERT {
+              <${newWebId}> <https://www.w3.org/ns/activitystreams#preferredUsername> "${uuid}" .
+            }
+            WHERE {
+              <${newWebId}> <https://www.w3.org/ns/activitystreams#preferredUsername> ?o .
+            }
+          `,
+          webId: 'system',
+        });
+
+        // Update WebACL
+        await update({
+          query: `
+            DELETE {
+              GRAPH <http://semapps.org/webacl> {
+                <${oldWebId}${suffix}> ?p ?o .
+                ?s ?p2 <${oldWebId}${suffix}> .
+              }
+            }
+            INSERT {
+              GRAPH <http://semapps.org/webacl> {
+                <${newWebId}${suffix}> ?p ?o .
+                ?s ?p2 <${newWebId}${suffix}> .
+              }
+            }
+            WHERE {
+              GRAPH <http://semapps.org/webacl> {
+                {
+                  <${oldWebId}${suffix}> ?p ?o .
+                }
+                UNION
+                {
+                  ?s ?p2 <${oldWebId}${suffix}> .
+                }
+              }
+            }
+          `,
+          webId: 'system',
+        });
+
+        const oldAclWebId = oldWebId.replace('/users/', '/_acl/users/');
+        const newAclWebId = newWebId.replace('/users/', '/_acl/users/');
+        const aclSuffixes = ['#Read', '#Write', '#Control', '#Append'];
+
+        for (let aclSuffix of aclSuffixes) {
+          console.log(`Updating ACL for ${oldWebId}${suffix}${aclSuffix}...`);
+          await update({
+            query: `
+              DELETE {
+                GRAPH <http://semapps.org/webacl> {
+                  <${oldAclWebId}${suffix}${aclSuffix}> ?p ?o .
+                }
+              }
+              INSERT {
+                GRAPH <http://semapps.org/webacl> {
+                  <${newAclWebId}${suffix}${aclSuffix}> ?p ?o .
+                }
+              }
+              WHERE {
+                GRAPH <http://semapps.org/webacl> {
+                  <${oldAclWebId}${suffix}${aclSuffix}> ?p ?o .
+                }
+              }
+            `,
+            webId: 'system',
+          });
+        }
+      }
+
+    }
+  },
+  down: async ({ query, insert, update, call }) => {
+    // No down migration
+  },
+};

--- a/middleware/migrations/1734283718845_archipelago-removeOrphanUsers.js
+++ b/middleware/migrations/1734283718845_archipelago-removeOrphanUsers.js
@@ -1,0 +1,32 @@
+module.exports = {
+  up: async ({ query, insert, update, call }) => {
+
+    const activeUsers = await query({
+      query: `
+        SELECT ?s
+        WHERE {
+          ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://virtual-assembly.org/ontologies/pair#Person>
+        }
+      `,
+      webId: 'system',
+    });
+
+    const webIds = activeUsers.map(user => `"${user.s.value}"`);
+
+    await update({
+      query: `
+        DELETE {
+          ?subject ?predicate ?object .
+        } WHERE {
+          ?subject ?predicate ?object .
+          ?subject <http://semapps.org/ns/core#webId> ?webid .
+          FILTER(?webid NOT IN (${webIds.join(',')}))
+        }
+      `,
+      dataset: 'settings',
+    });
+  },
+  down: async ({ query, insert, update, call }) => {
+    // No down migration
+  },
+};


### PR DESCRIPTION
Hello,

Je propose dans cette PR deux migrations en base de données pour faire suite à la PR #212 sur la gestion des utilisateurs : 

- La première permet d'anonymiser les webIds des utilisateurs déjà créés. Cela inclue également les clés liés à activityPub (/inbox, /outbox, /followers, /following, /liked)

- La seconde permet de supprimer les utilisateurs existants dans le dataset Settings mais non-existants dans le dataset LocalData (par exemples les personnes ayant tenté de supprimer leur compte avant le déploiement de la PR précédente)

Pour rappel, deux autres migrations de suppression de données n'ont pas été inclus pour les exécuter consciencieusement à la main lors de la migration puisqu'elles traitent de suppression volontaire de données. Elles seront incluses dans le guide de migration vers la version 2.4.0 d'Archipelago.

```sparql
# Suppression des données FOAF/*
DELETE { 
  ?s ?p ?o
} WHERE {
  ?s ?p ?o .
  FILTER(?p IN (
    <http://xmlns.com/foaf/0.1/name>,
    <http://xmlns.com/foaf/0.1/familyName>,
    <http://xmlns.com/foaf/0.1/email>,
    <http://xmlns.com/foaf/0.1/nick>
  ))
}
```

```sparql
# Suppression des données PAIR/e-mail pour les personnes
DELETE WHERE {
  ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://virtual-assembly.org/ontologies/pair#Person> .
  ?s <http://virtual-assembly.org/ontologies/pair#e-mail> ?o
}
```