### PR TITLE
Use CustomTree for all themes input

### DIFF
--- a/frontend/src/resources/Agent/Activity/Event/EventForm.jsx
+++ b/frontend/src/resources/Agent/Activity/Event/EventForm.jsx
@@ -9,10 +9,10 @@ import { MarkdownInput } from '@semapps/markdown-components';
 import { ImageInput } from "@semapps/input-components";
 import {
   ActorsInput,
-  ThemesInput,
   DateTimeInput,
   LocationInput,
 } from "../../../../common/input";
+import CustomTreeSelectArrayInput from '../../../../common/input/TreeComponent/CustomTreeSelectArrayInput';
 
 import LargeLabel from "../../../../common/list/MainList/LargeLabel";
 import { Stack } from "@mui/material";
@@ -76,7 +76,7 @@ const EventForm = () => {
         source="pair:involves"
         helperText="Indiquez ici les organisations, groupes ou personnes qui sont impliqués dans l'évènement"
       />
-      <ThemesInput source="pair:hasTopic" />
+      <CustomTreeSelectArrayInput source="pair:hasTopic" reference="Theme" label="A pour thème" broader="pair:broader" fullWidth />
       <TextInput
         source="pair:aboutPage"
         fullWidth

--- a/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectEdit.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { ImageField, SelectInput, TextInput, TabbedForm, FormTab, ReferenceInput } from 'react-admin';
 import { MarkdownInput } from '@semapps/markdown-components';
-import { ActorsInput, DocumentsInput, ThemesInput, ResourcesInput } from '../../../../common/input';
+import { ActorsInput, DocumentsInput, ResourcesInput } from '../../../../common/input';
 import { ImageInput } from '@semapps/input-components';
 import { EditToolbarWithPermissions } from '@semapps/auth-provider';
 import { Edit } from '../../../../common/layout';
+import CustomTreeSelectArrayInput from '../../../../common/input/TreeComponent/CustomTreeSelectArrayInput';
 
 const ProjectEdit = props => (
   <Edit redirect="show" {...props}>
@@ -28,7 +29,7 @@ const ProjectEdit = props => (
         <ActorsInput source="pair:involves" />
         <ResourcesInput source="pair:needs" />
         <DocumentsInput source="pair:documentedBy" />
-        <ThemesInput source="pair:hasTopic" />
+        <CustomTreeSelectArrayInput source="pair:hasTopic" reference="Theme" label="A pour thème" broader="pair:broader" fullWidth />
       </FormTab>
     </TabbedForm>
   </Edit>

--- a/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
+++ b/frontend/src/resources/Agent/Actor/Person/PersonEdit.jsx
@@ -3,9 +3,10 @@ import { ImageField, TabbedForm, TextInput, FormTab, SaveButton, Toolbar as RaTo
 import { MarkdownInput } from '@semapps/markdown-components';
 import { ImageInput } from '@semapps/input-components';
 import { DeleteButtonWithPermissions } from '@semapps/auth-provider';
-import { ActivitiesInput, LocationInput, SkillsInput, ThemesInput } from '../../../../common/input';
+import { ActivitiesInput, LocationInput, SkillsInput } from '../../../../common/input';
 import { Edit } from '../../../../common/layout';
 import MembershipAssociationInput from '../../../../common/input/MembershipAssociationInput';
+import CustomTreeSelectArrayInput from '../../../../common/input/TreeComponent/CustomTreeSelectArrayInput';
 
 export const PersonEdit = (props) => {
   const redirect = useRedirect();
@@ -67,8 +68,8 @@ export const PersonEdit = (props) => {
         <FormTab label="Relations">
           <ActivitiesInput source="pair:involvedIn" />
           <SkillsInput source="pair:offers" />
-          <ThemesInput source="pair:hasTopic" />
-        </FormTab>
+          <CustomTreeSelectArrayInput source="pair:hasTopic" reference="Theme" label="A pour thème" broader="pair:broader" fullWidth />
+          </FormTab>
       </TabbedForm>
     </Edit>
   );


### PR DESCRIPTION
Il semble que depuis la création du composant CustomTreeSelectArrayInput (par @simonLouvet et Bastien), ce composant n'ait été affecté que pour les organisations.

Or, pour les autres ressources, l'ancien composant ThemesInput ne semble plus fonctionner.

![image](https://github.com/user-attachments/assets/d7b7cda5-87ff-4310-9d86-b17eb43d70c2)

Je propose donc d'utiliser le nouveau composant partout.

![image](https://github.com/user-attachments/assets/1759c512-daea-4e8d-9bb2-d90147a86e13)
