### PR TITLE
Add filter orga in projects & projects in orgas

### DIFF
--- a/frontend/src/resources/Agent/Activity/Project/ProjectFilterSidebar.tsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectFilterSidebar.tsx
@@ -33,6 +33,12 @@ const ProjectFilterSidebar = () => {
         filter={{ a: 'pair:ProjectType' }}
         sort={{ field: 'pair:label', order: 'DESC' }}
       />
+      <ReferenceFilter
+        reference="Organization"
+        source="pair:involves"
+        limit={100}
+        sort={{ field: 'pair:label', order: 'DESC' }}
+      />
     </Layout.Aside>
   );
 };

--- a/frontend/src/resources/Agent/Actor/Organization/OrganizationFilterSidebar.tsx
+++ b/frontend/src/resources/Agent/Actor/Organization/OrganizationFilterSidebar.tsx
@@ -30,6 +30,15 @@ const OrganizationFilterSidebar = () => {
         filter={{}}
         sort={{ field: 'pair:label', order: 'DESC' }}
       />
+      <ReferenceFilterTree
+        reference="Project"
+        title="Projets"
+        broader="pair:broader"
+        source="pair:involvedIn"
+        label="pair:label"
+        filter={{}}
+        sort={{ field: 'pair:label', order: 'DESC' }}
+      />
     </Layout.Aside>
   );
 };


### PR DESCRIPTION
Suite à la demande du Low-tech Lab, j'ai ajouté un filtre "Organisation" dans la liste des projets

![image](https://github.com/user-attachments/assets/a17cbd15-97af-4fc7-bf31-f3338321463a)

Vu que la liste des organisations peut être longue, je l'ai mis en bas...

Puis, dans l'autre sens, j'ai ajouté un filtre "Projets" dans la liste des organisations.

![image](https://github.com/user-attachments/assets/108ec492-f4fe-4280-a84c-49a0a203759d)

J'ai testé, et ça filtre bien dans les deux cas.