### PR TITLE
[Patch] Filter only on resources name

### DIFF
--- a/frontend/src/resources/Agent/Activity/Event/EventFilterSidebar.tsx
+++ b/frontend/src/resources/Agent/Activity/Event/EventFilterSidebar.tsx
@@ -10,7 +10,7 @@ const EventFilterSidebar = () => {
   return (
     <Layout.Aside>
       {Layout.name === 'topMenu' && (
-        <FilterLiveSearch fullWidth source="q" hiddenLabel label={translate('resources.Event.searchLabel')} />
+        <FilterLiveSearch fullWidth source="pair:label" hiddenLabel label={translate('resources.Event.searchLabel')} />
       )}
       <ReferenceFilterTree
         reference="Theme"

--- a/frontend/src/resources/Agent/Activity/Project/ProjectFilterSidebar.tsx
+++ b/frontend/src/resources/Agent/Activity/Project/ProjectFilterSidebar.tsx
@@ -11,7 +11,7 @@ const ProjectFilterSidebar = () => {
   return (
     <Layout.Aside>
       {Layout.name === 'topMenu' && (
-        <FilterLiveSearch fullWidth source="q" hiddenLabel label={translate('resources.Project.searchLabel')} />
+        <FilterLiveSearch fullWidth source="pair:label" hiddenLabel label={translate('resources.Project.searchLabel')} />
       )}
       <ReferenceFilter
         reference="Status"

--- a/frontend/src/resources/Agent/Activity/Task/TaskFilterSidebar.tsx
+++ b/frontend/src/resources/Agent/Activity/Task/TaskFilterSidebar.tsx
@@ -10,7 +10,7 @@ const TaskFilterSidebar = () => {
   return (
     <Layout.Aside>
       {Layout.name === 'topMenu' && (
-        <FilterLiveSearch fullWidth source="q" hiddenLabel label={translate('resources.Task.searchLabel')} />
+        <FilterLiveSearch fullWidth source="pair:label" hiddenLabel label={translate('resources.Task.searchLabel')} />
       )}
       <ReferenceFilter
         reference="Status"

--- a/frontend/src/resources/Agent/Actor/Organization/OrganizationFilterSidebar.tsx
+++ b/frontend/src/resources/Agent/Actor/Organization/OrganizationFilterSidebar.tsx
@@ -11,7 +11,7 @@ const OrganizationFilterSidebar = () => {
   return (
     <Layout.Aside>
       {Layout.name === 'topMenu' && (
-        <FilterLiveSearch fullWidth source="q" hiddenLabel label={translate('resources.Organization.searchLabel')} />
+        <FilterLiveSearch fullWidth source="pair:label" hiddenLabel label={translate('resources.Organization.searchLabel')} />
       )}
       <ReferenceFilter
         reference="Type"

--- a/frontend/src/resources/Agent/Actor/Person/PersonFilterSidebar.tsx
+++ b/frontend/src/resources/Agent/Actor/Person/PersonFilterSidebar.tsx
@@ -10,7 +10,7 @@ const PersonFilterSidebar = () => {
   return (
     <Layout.Aside>
       {Layout.name === 'topMenu' && (
-        <FilterLiveSearch fullWidth source="q" hiddenLabel label={translate('resources.Person.searchLabel')} />
+        <FilterLiveSearch fullWidth source="pair:label" hiddenLabel label={translate('resources.Person.searchLabel')} />
       )}
       <ReferenceFilter
         label="Intérêts"

--- a/frontend/src/resources/Idea/IdeaFilterSidebar.tsx
+++ b/frontend/src/resources/Idea/IdeaFilterSidebar.tsx
@@ -10,7 +10,7 @@ const IdeaFilterSidebar = () => {
   return (
     <Layout.Aside>
       {Layout.name === 'topMenu' && (
-        <FilterLiveSearch fullWidth source="q" hiddenLabel label={translate('resources.Idea.searchLabel')} />
+        <FilterLiveSearch fullWidth source="pair:label" hiddenLabel label={translate('resources.Idea.searchLabel')} />
       )}
       <ReferenceFilter
         reference="Status"


### PR DESCRIPTION
La recherche s'effectue actuellement sur tous les attributs des ressources, donnant des résultats incohérents.
Cette PR corrige ce comportement en ne ciblant la recherche que sur le nom des ressources.

⚠️  Pour l'instant, les minuscules/majuscules et les accents ne sont pas gérés correctement. Ils le seront quand https://github.com/assemblee-virtuelle/semapps/pull/1431 sera mergée et le semantic-data-provider mis-à-jour.